### PR TITLE
Added support charts for basic form elements

### DIFF
--- a/_features/html-button-reset.md
+++ b/_features/html-button-reset.md
@@ -1,0 +1,88 @@
+---
+title: "Reset input"
+description: "HTML button type reset"
+category: html
+keywords: form, reset, button
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y",
+            "12.4":"y"
+        },
+        ios: {
+            "10.3":"y",
+            "12.4":"y"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"a #1"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-06":"n"
+        },
+        android: {
+            "2019-06":"y"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"y",
+            "9.0":"y"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"n"
+        },
+        ios: {
+            "2019-09":"n"
+        },
+        android: {
+            "2019-09":"n"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "n"
+        },
+        ios: {
+            "2019-09": "n"
+        },
+        android: {
+            "2019-09": "n"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+  "1": "Does not work in iOS GANGA"
+}
+---

--- a/_features/html-button-reset.md
+++ b/_features/html-button-reset.md
@@ -1,11 +1,11 @@
 ---
-title: "Reset input"
+title: "<button type=\"reset\"> element"
 description: "HTML button type reset"
 category: html
 keywords: form, reset, button
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {
@@ -83,6 +83,6 @@ stats: {
 }
 notes: ""
 notes_by_num: {
-  "1": "Does not work in iOS GANGA"
+  "1": "Partial. Not supported with non Gmail accounts."
 }
 ---

--- a/_features/html-button-submit.md
+++ b/_features/html-button-submit.md
@@ -1,11 +1,11 @@
 ---
-title: "Submit input"
+title: "<button type=\"submit\"> element"
 description: "HTML button type submit"
 category: html
 keywords: form, submit, button
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {
@@ -83,6 +83,6 @@ stats: {
 }
 notes: ""
 notes_by_num: {
-  "1": "Does not work in iOS GANGA"
+  "1": "Partial. Not supported with non Gmail accounts."
 }
 ---

--- a/_features/html-button-submit.md
+++ b/_features/html-button-submit.md
@@ -1,0 +1,88 @@
+---
+title: "Submit input"
+description: "HTML button type submit"
+category: html
+keywords: form, submit, button
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y",
+            "12.4":"y"
+        },
+        ios: {
+            "10.3":"y",
+            "12.4":"y"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"a #1"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-06":"n"
+        },
+        android: {
+            "2019-06":"y"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"y",
+            "9.0":"y"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"n"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "y"
+        },
+        ios: {
+            "2019-09": "y"
+        },
+        android: {
+            "2019-09": "y"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+  "1": "Does not work in iOS GANGA"
+}
+---

--- a/_features/html-form.md
+++ b/_features/html-form.md
@@ -1,0 +1,89 @@
+---
+title: "Form"
+description: "The ability to submit an HTML form via email, this requires support of at least one form element, at least one form method and either input submit or button submit to pass data to an end point."
+category: html
+keywords: form
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y",
+            "12.4":"y"
+        },
+        ios: {
+            "10.3":"y",
+            "12.4":"y"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"a #1"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        outlook-com: {
+            "2019-09":"y #2"
+        },
+        ios: {
+            "2019-06":"y"
+        },
+        android: {
+            "2019-06":"y"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"y",
+            "9.0":"y"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"n"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "y"
+        },
+        ios: {
+            "2019-09": "y"
+        },
+        android: {
+            "2019-09": "y"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+  "1": "Does not submit in iOS GANGA",
+  "2": "On submit name values are prefixed with x_"
+}
+---

--- a/_features/html-form.md
+++ b/_features/html-form.md
@@ -1,11 +1,11 @@
 ---
-title: "Form"
+title: "<form> element"
 description: "The ability to submit an HTML form via email, this requires support of at least one form element, at least one form method and either input submit or button submit to pass data to an end point."
 category: html
 keywords: form
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {

--- a/_features/html-input-checkbox.md
+++ b/_features/html-input-checkbox.md
@@ -1,0 +1,88 @@
+---
+title: "Checkbox"
+description: "HTML input type checkbox"
+category: html
+keywords: form, checkbox
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y",
+            "12.4":"y"
+        },
+        ios: {
+            "10.3":"y",
+            "12.4":"y"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-06":"y"
+        },
+        android: {
+            "2019-06":"y"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"y",
+            "9.0":"y"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "y"
+        },
+        ios: {
+            "2019-09": "y"
+        },
+        android: {
+            "2019-09": "y"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+
+}
+---

--- a/_features/html-input-checkbox.md
+++ b/_features/html-input-checkbox.md
@@ -1,11 +1,11 @@
 ---
-title: "Checkbox"
+title: "<input type=\"checkbox\"> element"
 description: "HTML input type checkbox"
 category: html
 keywords: form, checkbox
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {

--- a/_features/html-input-hidden.md
+++ b/_features/html-input-hidden.md
@@ -1,11 +1,11 @@
 ---
-title: "hidden input"
+title: "<input type=\"hidden\"> element"
 description: "HTML input type hidden"
 category: html
 keywords: form, hidden
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {

--- a/_features/html-input-hidden.md
+++ b/_features/html-input-hidden.md
@@ -1,0 +1,88 @@
+---
+title: "hidden input"
+description: "HTML input type hidden"
+category: html
+keywords: form, hidden
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y",
+            "12.4":"y"
+        },
+        ios: {
+            "10.3":"y",
+            "12.4":"y"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-06":"y"
+        },
+        android: {
+            "2019-06":"y"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"y",
+            "9.0":"y"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "y"
+        },
+        ios: {
+            "2019-09": "y"
+        },
+        android: {
+            "2019-09": "y"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+
+}
+---

--- a/_features/html-input-radio.md
+++ b/_features/html-input-radio.md
@@ -1,0 +1,88 @@
+---
+title: "Radio buttons"
+description: "HTML input type radio"
+category: html
+keywords: form, radio
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y",
+            "12.4":"y"
+        },
+        ios: {
+            "10.3":"y",
+            "12.4":"y"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-06":"y"
+        },
+        android: {
+            "2019-06":"y"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"y",
+            "9.0":"y"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "y"
+        },
+        ios: {
+            "2019-09": "y"
+        },
+        android: {
+            "2019-09": "y"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+
+}
+---

--- a/_features/html-input-radio.md
+++ b/_features/html-input-radio.md
@@ -1,11 +1,11 @@
 ---
-title: "Radio buttons"
+title: "<input type=\"radio\"> element"
 description: "HTML input type radio"
 category: html
 keywords: form, radio
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {

--- a/_features/html-input-reset.md
+++ b/_features/html-input-reset.md
@@ -1,11 +1,11 @@
 ---
-title: "Reset input"
+title: "<input type=\"reset\"> element"
 description: "HTML input type reset"
 category: html
 keywords: form, reset
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {
@@ -83,6 +83,6 @@ stats: {
 }
 notes: ""
 notes_by_num: {
-  "1": "Does not work in iOS GANGA"
+  "1": "Partial. Not supported with non Gmail accounts."
 }
 ---

--- a/_features/html-input-reset.md
+++ b/_features/html-input-reset.md
@@ -1,0 +1,88 @@
+---
+title: "Reset input"
+description: "HTML input type reset"
+category: html
+keywords: form, reset
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y",
+            "12.4":"y"
+        },
+        ios: {
+            "10.3":"y",
+            "12.4":"y"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"a #1"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-06":"y"
+        },
+        android: {
+            "2019-06":"y"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"y",
+            "9.0":"y"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "y"
+        },
+        ios: {
+            "2019-09": "y"
+        },
+        android: {
+            "2019-09": "y"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+  "1": "Does not work in iOS GANGA"
+}
+---

--- a/_features/html-input-submit.md
+++ b/_features/html-input-submit.md
@@ -1,0 +1,88 @@
+---
+title: "Submit input"
+description: "HTML input type submit"
+category: html
+keywords: form, submit
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y",
+            "12.4":"y"
+        },
+        ios: {
+            "10.3":"y",
+            "12.4":"y"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"a #1"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-06":"y"
+        },
+        android: {
+            "2019-06":"y"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"y",
+            "9.0":"y"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"n"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "y"
+        },
+        ios: {
+            "2019-09": "y"
+        },
+        android: {
+            "2019-09": "y"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+  "1": "Does not work in iOS GANGA"
+}
+---

--- a/_features/html-input-submit.md
+++ b/_features/html-input-submit.md
@@ -1,11 +1,11 @@
 ---
-title: "Submit input"
+title: "<input type=\"submit\"> element"
 description: "HTML input type submit"
 category: html
 keywords: form, submit
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {
@@ -83,6 +83,10 @@ stats: {
 }
 notes: ""
 notes_by_num: {
-  "1": "Does not work in iOS GANGA"
+  "1": "Partial. Not supported with non Gmail accounts."
+}
+links: {
+    "Can I use: HTML element: input: type=\"submit\"":"https://caniuse.com/#feat=mdn-html_elements_input_input-submit",
+    "MDN: <input: type=\"submit\">":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/submit"
 }
 ---

--- a/_features/html-input-submit.md
+++ b/_features/html-input-submit.md
@@ -86,7 +86,7 @@ notes_by_num: {
   "1": "Partial. Not supported with non Gmail accounts."
 }
 links: {
-    "Can I use: HTML element: input: type=\"submit\"":"https://caniuse.com/#feat=mdn-html_elements_input_input-submit",
-    "MDN: <input: type=\"submit\">":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/submit"
+    "Can I use: `<input type=\"submit\">`":"https://caniuse.com/#feat=mdn-html_elements_input_input-submit",
+    "MDN: `<input type=\"submit\">`":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/submit"
 }
 ---

--- a/_features/html-input-text.md
+++ b/_features/html-input-text.md
@@ -1,11 +1,11 @@
 ---
-title: "Text input"
+title: "<input type=\"text\"> element"
 description: "HTML input type text"
 category: html
 keywords: form, text
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {
@@ -83,8 +83,8 @@ stats: {
 }
 notes: ""
 notes_by_num: {
-  "1": "Email scrolls to the end when space bar is pressed.  This can be fixed by wrapping the `<input>` in `<ul role=/"presentation/">` ",
-  "2": "Screen jumps when input is in focus",
-  "3": "A number of android clients will not show the keyboard when the input is clicked.  Copy and pasting text works."
+  "1": "Buggy. Email scrolls to the end when space bar is pressed.  This can be fixed by wrapping the `<input>` in `<ul role=\"presentation\">`.",
+  "2": "Buggy. Screen jumps when input is in focus.",
+  "3": "Buggy. A number of Android clients will not show the keyboard when the input is clicked. Copy and pasting text works."
 }
 ---

--- a/_features/html-input-text.md
+++ b/_features/html-input-text.md
@@ -1,0 +1,90 @@
+---
+title: "Text input"
+description: "HTML input type text"
+category: html
+keywords: form, text
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y #1",
+            "12.4":"y #1"
+        },
+        ios: {
+            "10.3":"y #2",
+            "12.4":"y #2"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-06":"y"
+        },
+        android: {
+            "2019-06":"n #3"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"n #3",
+            "9.0":"n #3"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"n #3"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "y"
+        },
+        ios: {
+            "2019-09": "y"
+        },
+        android: {
+            "2019-09": "y"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+  "1": "Email scrolls to the end when space bar is pressed.  This can be fixed by wrapping the `<input>` in `<ul role=/"presentation/">` ",
+  "2": "Screen jumps when input is in focus",
+  "3": "A number of android clients will not show the keyboard when the input is clicked.  Copy and pasting text works."
+}
+---

--- a/_features/html-required.md
+++ b/_features/html-required.md
@@ -1,0 +1,88 @@
+---
+title: "Required"
+description: "Required attribute on form elements"
+category: html
+keywords: form, required
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y",
+            "12.4":"y"
+        },
+        ios: {
+            "10.3":"y",
+            "12.4":"y"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"n"
+        },
+        ios: {
+            "2019-09":"n"
+        },
+        android: {
+            "2019-09":"a #1"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"n"
+        },
+        ios: {
+            "2019-06":"y"
+        },
+        android: {
+            "2019-06":"y"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"y",
+            "9.0":"y"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"n"
+        },
+        ios: {
+            "2019-09":"n"
+        },
+        android: {
+            "2019-09":"n"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09":"n"
+        },
+        ios: {
+            "2019-09": "n"
+        },
+        android: {
+            "2019-09": "n"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+  "1": "Only works in Android GANGA"
+}
+---

--- a/_features/html-required.md
+++ b/_features/html-required.md
@@ -1,11 +1,11 @@
 ---
-title: "Required"
+title: "required attribute"
 description: "Required attribute on form elements"
 category: html
 keywords: form, required
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {
@@ -83,6 +83,6 @@ stats: {
 }
 notes: ""
 notes_by_num: {
-  "1": "Only works in Android GANGA"
+  "1": "Partial. Only supported with non Gmail accounts."
 }
 ---

--- a/_features/html-select.md
+++ b/_features/html-select.md
@@ -1,11 +1,11 @@
 ---
-title: "Select"
+title: "<select> element"
 description: "HTML select menu"
 category: html
 keywords: form, select
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {
@@ -83,6 +83,6 @@ stats: {
 }
 notes: ""
 notes_by_num: {
-  "1": "If the email is shorter than the viewport it works, otherwise the screen goes blank when the select is in focus"
+  "1": "Buggy. Works if the email is shorter than the viewport. Otherwise the screen goes blank when the `<select>`.` is in focus"
 }
 ---

--- a/_features/html-select.md
+++ b/_features/html-select.md
@@ -83,6 +83,6 @@ stats: {
 }
 notes: ""
 notes_by_num: {
-  "1": "Buggy. Works if the email is shorter than the viewport. Otherwise the screen goes blank when the `<select>`.` is in focus"
+  "1": "Buggy. Works if the email is shorter than the viewport. Otherwise the screen goes blank when the `<select>` is in focus."
 }
 ---

--- a/_features/html-select.md
+++ b/_features/html-select.md
@@ -1,0 +1,88 @@
+---
+title: "Select"
+description: "HTML select menu"
+category: html
+keywords: form, select
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y",
+            "12.4":"y"
+        },
+        ios: {
+            "10.3":"a #1",
+            "12.4":"a #1"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"a #1"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-06":"y"
+        },
+        android: {
+            "2019-06":"y"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"y",
+            "9.0":"y"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"n"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "y"
+        },
+        ios: {
+            "2019-09": "y"
+        },
+        android: {
+            "2019-09": "y"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+  "1": "If the email is shorter than the viewport it works, otherwise the screen goes blank when the select is in focus"
+}
+---

--- a/_features/html-textarea.md
+++ b/_features/html-textarea.md
@@ -1,11 +1,11 @@
 ---
-title: "Text input"
+title: "<textarea> element"
 description: "HTML input type text"
 category: html
 keywords: form, text
 last_test_date: "2019-09-10"
 test_url: "tests/html-forms.html"
-test_results_url: ""
+test_results_url: "https://app.emailonacid.com/app/acidtest/MOk8g8TWwCTL4vLGrdMIgu3Vncqdxif6KlK4g8HfUV1mB/list"
 stats: {
     apple-mail: {
         macos: {
@@ -83,8 +83,8 @@ stats: {
 }
 notes: ""
 notes_by_num: {
-  "1": "Email scrolls to the end when space bar is pressed.  This can be fixed by wrapping the `<input>` in `<ul role=/"presentation/">` ",
-  "2": "Screen jumps when input is in focus",
-  "3": "A number of android clients will not show the keyboard when the input is clicked.  Copy and pasting text works."
+  "1": "Buggy. Email scrolls to the end when space bar is pressed.  This can be fixed by wrapping the `<input>` in `<ul role=\"presentation\">`.",
+  "2": "Buggy. Screen jumps when input is in focus.",
+  "3": "Buggy. A number of android clients will not show the keyboard when the input is clicked.  Copy and pasting text works."
 }
 ---

--- a/_features/html-textarea.md
+++ b/_features/html-textarea.md
@@ -1,0 +1,90 @@
+---
+title: "Text input"
+description: "HTML input type text"
+category: html
+keywords: form, text
+last_test_date: "2019-09-10"
+test_url: "tests/html-forms.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "10.3":"y #1",
+            "12.4":"y #1"
+        },
+        ios: {
+            "10.3":"y #2",
+            "12.4":"y #2"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"y"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        macos: {
+            "2011":"y",
+            "2016":"y",
+            "2019":"y"
+        },
+        outlook-com: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-06":"y"
+        },
+        android: {
+            "2019-06":"n #3"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"n #3",
+            "9.0":"n #3"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2019-09":"y"
+        },
+        ios: {
+            "2019-09":"y"
+        },
+        android: {
+            "2019-09":"n #3"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2019-09": "y"
+        },
+        ios: {
+            "2019-09": "y"
+        },
+        android: {
+            "2019-09": "y"
+        }
+    }
+}
+notes: ""
+notes_by_num: {
+  "1": "Email scrolls to the end when space bar is pressed.  This can be fixed by wrapping the `<input>` in `<ul role=/"presentation/">` ",
+  "2": "Screen jumps when input is in focus",
+  "3": "A number of android clients will not show the keyboard when the input is clicked.  Copy and pasting text works."
+}
+---


### PR DESCRIPTION
I've not done everything that was in the spreadsheet just the main ones.

Also for the `html-form.md` file, this support is referring to a fully functioning form that can submit data rather than support of the `<form>` element. 

Also before merging may be worth checking the formatting on the comments in `html-input-text.md` & `html-textarea.md` don't break anything, I think I've used the correct format but not 100%

```
notes_by_num: {
  "1": "Email scrolls to the end when space bar is pressed.  This can be fixed by wrapping the `<input>` in `<ul role=/"presentation/">` ",
```