### PR TITLE
feature.html: Fix link to CONTRIBUTING.md

### DIFF
--- a/_layouts/feature.html
+++ b/_layouts/feature.html
@@ -248,7 +248,7 @@ layout: default
 			</p>
 			{% endif %}
 			<p>
-				If you want to test this feature in the same conditions as we did, you can get our test code and run a test by yourself. Make sure to follow our <a href="https://www.github.com/hteumeuleu/caniemail/blob/master/contributing.md">testing recommendations</a> first.
+				If you want to test this feature in the same conditions as we did, you can get our test code and run a test by yourself. Make sure to follow our <a href="https://github.com/hteumeuleu/caniemail/blob/master/CONTRIBUTING.md">testing recommendations</a> first.
 			</p>
 			<p>
 				<a href="{{ page.test_url }}" class="feature-button">View the test code</a>


### PR DESCRIPTION
ef6d392 renamed contributing.md -> CONTRIBUTING.md.

Also, Github 301 redirects all www.github.com to github.com, so no need for www.