### PR TITLE
Add page about AMP support

### DIFF
--- a/_features/amp.md
+++ b/_features/amp.md
@@ -2,6 +2,8 @@
 title: "AMP for Email"
 description: "Support for rendering emails in the AMP format."
 category: html
+keywords: amp4email
+last_test_date: "2019-10-22"
 test_url: "/tests/amp.html"
 stats: {
 	apple-mail: {
@@ -76,7 +78,7 @@ stats: {
 	}
 }
 notes_by_num: {
-    "1": "In developer preview, turned off by default in user mailboxes."
+    "1": "Partially supported. Needs to be activated in _Settings > Mail > Message handling > Dynamic email_."
 }
 links: {
 	"AMP for Email Format":"https://amp.dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-format/?format=email",

--- a/_features/amp.md
+++ b/_features/amp.md
@@ -1,0 +1,86 @@
+---
+title: "AMP for Email"
+description: "Support for rendering emails in the AMP format."
+category: html
+test_url: "/tests/amp.html"
+stats: {
+	apple-mail: {
+		macos: {
+			"12.4":"n"
+		},
+		ios: {
+			"13.1":"n"
+		}
+	},
+	gmail: {
+		desktop-webmail: {
+			"2019-10":"y"
+		},
+		ios: {
+			"2019-10":"n"
+		},
+		android: {
+			"2019-10":"n"
+		}
+	},
+	outlook: {
+		windows: {
+			"2007":"n",
+			"2010":"n",
+			"2013":"n",
+			"2016":"n",
+			"2019":"n"
+		},
+		windows-10-mail: {
+			"2019-10":"n"
+		},
+		macos: {
+			"2019-10":"n"
+		},
+		outlook-com: {
+			"2019-10":"a #1"
+		},
+		ios: {
+			"2019-10":"n"
+		},
+		android: {
+			"2019-10":"n"
+		}
+	},
+	yahoo: {
+		desktop-webmail: {
+			"2019-10":"n"
+		},
+		ios: {
+			"2019-10":"n"
+		},
+		android: {
+			"2019-10":"n"
+		}
+	},
+	aol: {
+		desktop-webmail: {
+			"2019-10":"n"
+		},
+		ios: {
+			"2019-10":"n"
+		},
+		android: {
+			"2019-10":"n"
+		}
+	},
+	samsung-email: {
+		android: {
+			"5.0.10.2":"n"
+		}
+	}
+}
+notes_by_num: {
+    "1": "In developer preview, turned off by default in user mailboxes."
+}
+links: {
+	"AMP for Email Format":"https://amp.dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-format/?format=email",
+	"Gmail documentation on AMP":"https://developers.google.com/gmail/ampemail",
+	"Outlook.com documentation on AMP":"https://docs.microsoft.com/en-us/outlook/amphtml/"
+}
+---

--- a/tests/amp.html
+++ b/tests/amp.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html ⚡4email>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp4email-boilerplate>body{visibility:hidden}</style>
+</head>
+<body>
+  <h1>Hello, I am an AMP EMAIL!</h1>
+</body>
+</html>
+


### PR DESCRIPTION
Adds a page that tracks which email clients currently support the AMP for Email format.