### PR TITLE
CSS align-items property

### DIFF
--- a/_features/css-align-items.md
+++ b/_features/css-align-items.md
@@ -3,9 +3,9 @@ title: "align-items"
 description: ""
 category: css
 keywords: align,items,flexbox,grid
-last_test_date: "2020-12-26"
+last_test_date: "2021-03-09"
 test_url: "/tests/css-align-items.html"
-test_results_url: "https://testi.at/proj/ZlGcPZnfxlASABWiGn4t1xntZ"
+test_results_url: "https://app.emailonacid.com/app/acidtest/FvYneb1dhiR4we6rAOf4AC02oFa6ksA0sTWxbEjgmt6Mg/list"
 stats: {
 	apple-mail: {
 		macos: {
@@ -30,19 +30,19 @@ stats: {
 		android: {
 			"2020-12": "n"
 		},
-    mobile-webmail: {
+    	mobile-webmail: {
 			"2020-12": "n"
 		}
 	},
 	orange: {
 		desktop-webmail: {
-			"2020-12": "u"
+			"2021-03": "y"
 		},
 		ios: {
-			"2020-12": "u"
+			"2021-03": "y"
 		},
 		android: {
-			"2020-12": "u"
+			"2021-03": "y"
 		}
 	},
 	outlook: {
@@ -74,7 +74,7 @@ stats: {
 			"2020-12": "n"
 		},
 		ios: {
-			"2020-12": "u"
+			"2021-03": "n"
 		},
 		android: {
 			"6.16.2.1519779": "n"
@@ -85,10 +85,10 @@ stats: {
 			"2020-12": "n"
 		},
 		ios: {
-			"2020-12": "u"
+			"2021-03": "n"
 		},
 		android: {
-			"2020-12": "u"
+			"2021-03": "n"
 		}
 	},
 	samsung-email: {
@@ -98,13 +98,13 @@ stats: {
 	},
 	sfr: {
 		desktop-webmail: {
-			"2020-12": "u"
+			"2021-03": "y"
 		},
 		ios: {
-			"2020-12": "u"
+			"2021-03": "y"
 		},
 		android: {
-			"2020-12": "u"
+			"2021-03": "y"
 		}
 	},
 	thunderbird: {
@@ -114,18 +114,18 @@ stats: {
 	},
 	protonmail: {
 		desktop-webmail: {
-			"2020-12": "u"
+			"2021-03": "y"
 		},
 		ios: {
-			"2020-12": "u"
+			"2021-03": "y"
 		},
 		android: {
-			"2020-12": "u"
+			"2021-03": "y"
 		}
 	},
 	hey: {
 		desktop-webmail: {
-			"2020-12": "u"
+			"2021-03": "y"
 		}
 	},
 	mail-ru: {
@@ -136,6 +136,7 @@ stats: {
 }
 notes_by_num: {}
 links: {
-  "MDN: align-items":"https://developer.mozilla.org/en-US/docs/Web/CSS/align-items"
+	"MDN: align-items":"https://developer.mozilla.org/en-US/docs/Web/CSS/align-items",
+	"Can I use: flexbox":"https://caniuse.com/flexbox"
 }
 ---

--- a/_features/css-align-items.md
+++ b/_features/css-align-items.md
@@ -1,0 +1,141 @@
+---
+title: "align-items"
+description: ""
+category: css
+keywords: align,items,flexbox,grid
+last_test_date: "2020-12-26"
+test_url: "/tests/css-align-items.html"
+test_results_url: "https://testi.at/proj/ZlGcPZnfxlASABWiGn4t1xntZ"
+stats: {
+	apple-mail: {
+		macos: {
+			"11": "y",
+			"12": "y",
+			"13": "y"
+		},
+		ios: {
+			"11": "y",
+			"12": "y",
+			"13": "y",
+			"14": "y"
+		}
+	},
+	gmail: {
+		desktop-webmail: {
+			"2020-12": "n"
+		},
+		ios: {
+			"2020-12": "n"
+		},
+		android: {
+			"2020-12": "n"
+		},
+    mobile-webmail: {
+			"2020-12": "n"
+		}
+	},
+	orange: {
+		desktop-webmail: {
+			"2020-12": "u"
+		},
+		ios: {
+			"2020-12": "u"
+		},
+		android: {
+			"2020-12": "u"
+		}
+	},
+	outlook: {
+		windows: {
+			"2007": "n",
+			"2010": "n",
+			"2013": "n",
+			"2016": "n",
+			"2019": "n"
+		},
+		windows-10-mail: {
+			"2020-12": "n"
+		},
+		macos: {
+			"2020-12": "y"
+		},
+		outlook-com: {
+			"2020-12": "y"
+		},
+		ios: {
+			"2020-12": "y"
+		},
+		android: {
+			"4.2048.4": "y"
+		}
+	},
+	yahoo: {
+		desktop-webmail: {
+			"2020-12": "n"
+		},
+		ios: {
+			"2020-12": "u"
+		},
+		android: {
+			"6.16.2.1519779": "n"
+		}
+	},
+	aol: {
+		desktop-webmail: {
+			"2020-12": "n"
+		},
+		ios: {
+			"2020-12": "u"
+		},
+		android: {
+			"2020-12": "u"
+		}
+	},
+	samsung-email: {
+		android: {
+			"6.1.31.2": "y"
+		}
+	},
+	sfr: {
+		desktop-webmail: {
+			"2020-12": "u"
+		},
+		ios: {
+			"2020-12": "u"
+		},
+		android: {
+			"2020-12": "u"
+		}
+	},
+	thunderbird: {
+		macos: {
+			"2020-12": "y"
+		}
+	},
+	protonmail: {
+		desktop-webmail: {
+			"2020-12": "u"
+		},
+		ios: {
+			"2020-12": "u"
+		},
+		android: {
+			"2020-12": "u"
+		}
+	},
+	hey: {
+		desktop-webmail: {
+			"2020-12": "u"
+		}
+	},
+	mail-ru: {
+		desktop-webmail: {
+			"2020-12": "y"
+		}
+	}
+}
+notes_by_num: {}
+links: {
+  "MDN: align-items":"https://developer.mozilla.org/en-US/docs/Web/CSS/align-items"
+}
+---

--- a/tests/css-align-items.html
+++ b/tests/css-align-items.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>align-items CSS property</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+	<style>
+		h1, h2 {
+			font-size: 16px;
+			text-align: center;
+			font-family: monospace;
+		}
+	</style>
+</head>
+
+<body>
+	<h1>align-items CSS property</h1>
+
+	<h2>align-items: normal</h2>
+	<div style="display:flex; align-items:normal; height:150px; max-width:600px; background-color:#f5f5f5; margin:0 auto 50px;">
+		<div style="padding:5px; background-color:#000000; color:#ffffff;">consectetur</div>
+		<div style="padding:5px; background-color:#9932cc; color:#ffffff;">laboriosam</div>
+		<div style="padding:5px; background-color:#008b8b; color:#ffffff;">adipisicing</div>
+	</div>
+
+	<h2>align-items: baseline</h2>
+	<div style="display:flex; align-items:baseline; height:150px; max-width:600px; background-color:#f5f5f5; margin:0 auto 50px;">
+		<div style="padding:5px; background-color:#000000; color:#ffffff;">consectetur</div>
+		<div style="padding:5px; background-color:#9932cc; color:#ffffff;">laboriosam</div>
+		<div style="padding:5px; background-color:#008b8b; color:#ffffff;">adipisicing</div>
+	</div>
+
+	<h2>align-items: center</h2>
+	<div style="display:flex; align-items:center; height:150px; max-width:600px; background-color:#f5f5f5; margin:0 auto 50px;">
+		<div style="padding:5px; background-color:#000000; color:#ffffff;">consectetur</div>
+		<div style="padding:5px; background-color:#9932cc; color:#ffffff;">laboriosam</div>
+		<div style="padding:5px; background-color:#008b8b; color:#ffffff;">adipisicing</div>
+	</div>
+
+	<h2>align-items: flex-start</h2>
+	<div style="display:flex; align-items:flex-start; height:150px; max-width:600px; background-color:#f5f5f5; margin:0 auto 50px;">
+		<div style="padding:5px; background-color:#000000; color:#ffffff;">consectetur</div>
+		<div style="padding:5px; background-color:#9932cc; color:#ffffff;">laboriosam</div>
+		<div style="padding:5px; background-color:#008b8b; color:#ffffff;">adipisicing</div>
+	</div>
+
+	<h2>align-items: flex-end</h2>
+	<div style="display:flex; align-items:flex-end; height:150px; max-width:600px; background-color:#f5f5f5; margin:0 auto 50px;">
+		<div style="padding:5px; background-color:#000000; color:#ffffff;">consectetur</div>
+		<div style="padding:5px; background-color:#9932cc; color:#ffffff;">laboriosam</div>
+		<div style="padding:5px; background-color:#008b8b; color:#ffffff;">adipisicing</div>
+	</div>
+</body>
+
+</html>


### PR DESCRIPTION
This PR adds a test and the test data for the [align-items CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).

Notes:

- The HTML currently only tests `align-items` in a flexbox layout, but the property is also supported in grid layout.
- The HTML does not include tests for all possible values.