### PR TITLE
HTML <address>

### DIFF
--- a/_features/html-address.md
+++ b/_features/html-address.md
@@ -1,0 +1,142 @@
+---
+title: "address"
+description: ""
+category: html
+keywords: address
+last_test_date: "2020-01-17"
+test_url: "/tests/html-semantics.html"
+test_results_url: "https://app.emailonacid.com/app/acidtest/fel5GW8SquYS9SWxQHu5Z9s0IeTpLZcnf5ghDEqQFf5Je/list"
+stats: {
+	apple-mail: {
+		macos: {
+			"11": "y",
+			"12": "y",
+			"13": "y"
+		},
+		ios: {
+			"11": "y",
+			"12": "y",
+			"13": "y",
+			"14": "y"
+		}
+	},
+	gmail: {
+		desktop-webmail: {
+			"2020-12": "y"
+		},
+		ios: {
+			"2020-12": "y"
+		},
+		android: {
+			"2020-12": "y"
+		},
+		mobile-webmail: {
+			"2020-12": "y"
+		}
+	},
+	orange: {
+		desktop-webmail: {
+			"2020-12":"y"
+		},
+		ios: {
+			"2020-12":"y"
+		},
+		android: {
+			"2020-12":"y"
+		}
+	},
+	outlook: {
+		windows: {
+			"2007": "y",
+			"2010": "y",
+			"2013": "y",
+			"2016": "y",
+			"2019": "y"
+		},
+		windows-10-mail: {
+			"2020-12": "y"
+		},
+		macos: {
+			"2020-12": "y"
+		},
+		outlook-com: {
+			"2020-12": "y"
+		},
+		ios: {
+			"2020-12": "y"
+		},
+		android: {
+			"4.2048.4": "y"
+		}
+	},
+	yahoo: {
+		desktop-webmail: {
+			"2020-12": "y"
+		},
+		ios: {
+			"2020-12": "y"
+		},
+		android: {
+			"6.16.2.1519779": "y"
+		}
+	},
+	aol: {
+		desktop-webmail: {
+			"2020-12": "y"
+		},
+		ios: {
+			"2020-12": "y"
+		},
+		android: {
+			"2020-12": "y"
+		}
+	},
+	samsung-email: {
+		android: {
+			"6.1.31.": "y"
+		}
+	},
+	sfr: {
+		desktop-webmail: {
+			"2020-12":"y"
+		},
+		ios: {
+			"2020-12":"y"
+		},
+		android: {
+			"2020-12":"y"
+		}
+	},
+	thunderbird: {
+		macos: {
+			"78.5": "y"
+		}
+	},
+	protonmail: {
+		desktop-webmail: {
+			"2020-12":"y"
+		},
+		ios: {
+			"2020-12":"y"
+		},
+		android: {
+			"2020-12":"y"
+		}
+	},
+	hey: {
+		desktop-webmail: {
+			"2020-12":"y"
+		}
+	},
+	mail-ru: {
+		desktop-webmail: {
+			"2020-12":"y"
+		}
+	}
+}
+notes_by_num: {}
+links: {
+    "Can I use: HTML element address":"https://caniuse.com/mdn-html_elements_address",
+    "MDN: The Contact Address element":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address"
+}
+---


### PR DESCRIPTION
This PR adds the feature data for the [HTML address element ](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address). 

I listed `/tests/html-semantics.html` as the test, but I can create a separate test for `<address>` if preferred.