### PR TITLE
CSS font-weight

### DIFF
--- a/_features/css-font-weight.md
+++ b/_features/css-font-weight.md
@@ -36,13 +36,13 @@ stats: {
   },
   orange: {
     desktop-webmail: {
-      "2021-01":"a #1"
+      "2021-01":"y"
     },
     ios: {
-      "2021-01":"u"
+      "2021-01":"y"
     },
     android: {
-      "2021-01":"u"
+      "2021-01":"y"
     }
   },
   outlook: {
@@ -74,7 +74,7 @@ stats: {
       "2021-01": "a #1"
     },
     ios: {
-      "2021-01": "u"
+      "6.21.1": "a #1"
     },
     android: {
       "6.16.2.1525679": "a #1"
@@ -85,10 +85,10 @@ stats: {
       "2021-01": "a #1"
     },
     ios: {
-      "2021-01": "u"
+      "2021-01": "a #1"
     },
     android: {
-      "2021-01": "u"
+      "2021-01": "a #1"
     }
   },
   samsung-email: {
@@ -98,34 +98,34 @@ stats: {
   },
   sfr: {
     desktop-webmail: {
-      "2021-01":"u"
+      "2021-01":"y"
     },
     ios: {
-      "2021-01":"u"
+      "2021-01":"y"
     },
     android: {
-      "2021-01":"u"
+      "2021-01":"y"
     }
   },
   thunderbird: {
     macos: {
-      "2021-01": "a #1"
+      "2021-01": "y"
     }
   },
   protonmail: {
     desktop-webmail: {
-      "2021-01":"u"
+      "2021-01":"y"
     },
     ios: {
-      "2021-01":"u"
+      "2021-01":"y"
     },
     android: {
-      "2021-01":"u"
+      "2021-01":"y"
     }
   },
   hey: {
     desktop-webmail: {
-      "2021-01":"u"
+      "2021-01":"y"
     }
   },
   mail-ru: {
@@ -135,7 +135,7 @@ stats: {
   }
 }
 notes_by_num: {
-  "1": "`<number>` values are not supported as per CSS Fonts Level 4 where any `<number>` value between 1 and 1000 (inclusive) is a valid value. Only the following numeric values are supported: 100, 200, 300, 400, 500, 600, 700, 800, and 900."
+  "1": "Partial support. `<number>` values are not supported as per CSS Fonts Level 4 where any `<number>` value between 1 and 1000 (inclusive) is a valid value. Only the following numeric values are supported: 100, 200, 300, 400, 500, 600, 700, 800, and 900."
 }
 links: {
   "Can I use: CSS property: font-weight":"https://caniuse.com/mdn-css_properties_font-weight",

--- a/_features/css-font-weight.md
+++ b/_features/css-font-weight.md
@@ -1,0 +1,145 @@
+---
+title: "font-weight"
+description: ""
+category: css
+keywords: font,weight
+last_test_date: "2021-01-31"
+test_url: "/tests/css-font-weight.html"
+test_results_url: "https://testi.at/proj/5QnIVlijE5FP53uPe4Ty0F8P"
+stats: {
+  apple-mail: {
+    macos: {
+      "11": "y",
+      "12": "y",
+      "13": "y"
+    },
+    ios: {
+      "11": "y",
+      "12": "y",
+      "13": "y",
+      "14": "y"
+    }
+  },
+  gmail: {
+    desktop-webmail: {
+      "2021-01": "y"
+    },
+    ios: {
+      "2021-01": "y"
+    },
+    android: {
+      "2021-01": "y"
+    },
+    mobile-webmail: {
+      "2021-01": "y"
+    }
+  },
+  orange: {
+    desktop-webmail: {
+      "2021-01":"a #1"
+    },
+    ios: {
+      "2021-01":"u"
+    },
+    android: {
+      "2021-01":"u"
+    }
+  },
+  outlook: {
+    windows: {
+      "2007": "a #1",
+      "2010": "a #1",
+      "2013": "a #1",
+      "2016": "a #1",
+      "2019": "a #1"
+    },
+    windows-10-mail: {
+      "2021-01": "a #1"
+    },
+    macos: {
+      "2021-01": "y"
+    },
+    outlook-com: {
+      "2021-01": "y"
+    },
+    ios: {
+      "2021-01": "y"
+    },
+    android: {
+      "4.2101.1": "y"
+    }
+  },
+  yahoo: {
+    desktop-webmail: {
+      "2021-01": "a #1"
+    },
+    ios: {
+      "2021-01": "u"
+    },
+    android: {
+      "6.16.2.1525679": "a #1"
+    }
+  },
+  aol: {
+    desktop-webmail: {
+      "2021-01": "a #1"
+    },
+    ios: {
+      "2021-01": "u"
+    },
+    android: {
+      "2021-01": "u"
+    }
+  },
+  samsung-email: {
+    android: {
+      "6.1.31.2": "y"
+    }
+  },
+  sfr: {
+    desktop-webmail: {
+      "2021-01":"u"
+    },
+    ios: {
+      "2021-01":"u"
+    },
+    android: {
+      "2021-01":"u"
+    }
+  },
+  thunderbird: {
+    macos: {
+      "2021-01": "a #1"
+    }
+  },
+  protonmail: {
+    desktop-webmail: {
+      "2021-01":"u"
+    },
+    ios: {
+      "2021-01":"u"
+    },
+    android: {
+      "2021-01":"u"
+    }
+  },
+  hey: {
+    desktop-webmail: {
+      "2021-01":"u"
+    }
+  },
+  mail-ru: {
+    desktop-webmail: {
+      "2021-01":"y"
+    }
+  }
+}
+notes_by_num: {
+  "1": "`<number>` values are not supported as per CSS Fonts Level 4 where any `<number>` value between 1 and 1000 (inclusive) is a valid value. Only the following numeric values are supported: 100, 200, 300, 400, 500, 600, 700, 800, and 900."
+}
+links: {
+  "Can I use: CSS property: font-weight":"https://caniuse.com/mdn-css_properties_font-weight",
+  "Can I use: CSS property: font-weight: `<number>` syntax":"https://caniuse.com/mdn-css_properties_font-weight_number",
+  "MDN: font-weight":"https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight"
+}
+---

--- a/tests/css-font-weight.html
+++ b/tests/css-font-weight.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>font-weight</title>
+</head>
+<body>
+  <p style="font-weight:400;">font-weight:400</p>
+  <p style="font-weight:700;">font-weight:700</p>
+  
+  <p style="font-weight:normal;">font-weight:normal <span style="font-weight:bolder;">font-weight:bolder</span></p>
+  <p style="font-weight:bold;">font-weight:bold <span style="font-weight:lighter;">font-weight:lighter</span></p>
+
+  <p style="font-weight:888;">font-weight:888</p>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a test and the test results for the [font-weight CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight). Closes #69 

I've marked the feature as supported if the email client supports:

- The `normal`, `bold`, `lighter` and `bolder` keywords
- Any `<number>` value between `1` and `1000` as per the CSS Fonts Level 4 spec