### PR TITLE
CSS clip-path

### DIFF
--- a/_features/css-clip-path.md
+++ b/_features/css-clip-path.md
@@ -3,150 +3,150 @@ title: "clip-path"
 description: ""
 category: css
 keywords: clip,path,svg,mask
-last_test_date: "2021-02-01"
+last_test_date: "2021-03-09"
 test_url: "/tests/css-clip-path.html"
-test_results_url: "https://testi.at/proj/OgBCZJIoG0CGNDFrYGTx5L"
+test_results_url: "https://app.emailonacid.com/app/acidtest/wp9G5kZZ8sY3lne7CeGvMmPIlyBT2Wy0nBMBBAevQNgQO/list"
 stats: {
-  apple-mail: {
-    macos: {
-      "11": "n",
-      "12": "n",
-      "13": "y"
-    },
-    ios: {
-      "11": "n",
-      "12": "n",
-      "13": "n",
-      "14": "y"
-    }
-  },
-  gmail: {
-    desktop-webmail: {
-      "2021-02": "n"
-    },
-    ios: {
-      "2021-02": "n"
-    },
-    android: {
-      "2021-02": "n"
-    },
-    mobile-webmail: {
-      "2021-02": "n"
-    }
-  },
-  orange: {
-    desktop-webmail: {
-      "2021-02":"u"
-    },
-    ios: {
-      "2021-02":"u"
-    },
-    android: {
-      "2021-02":"u"
-    }
-  },
-  outlook: {
-    windows: {
-      "2007": "n",
-      "2010": "n",
-      "2013": "n",
-      "2016": "n",
-      "2019": "n"
-    },
-    windows-10-mail: {
-      "2021-02": "n"
-    },
-    macos: {
-      "2011": "n",
-      "2016": "n",
-      "2021-02": "y"
-    },
-    outlook-com: {
-      "2021-02": "n"
-    },
-    ios: {
-      "2021-02": "n"
-    },
-    android: {
-      "4.2101.1": "n"
-    }
-  },
-  yahoo: {
-    desktop-webmail: {
-      "2021-02": "n"
-    },
-    ios: {
-      "2021-02": "u"
-    },
-    android: {
-      "6.16.2.1525679": "n"
-    }
-  },
-  aol: {
-    desktop-webmail: {
-      "2021-02": "n"
-    },
-    ios: {
-      "2021-02": "u"
-    },
-    android: {
-      "2021-02": "u"
-    }
-  },
-  samsung-email: {
-    android: {
-      "6.1.31.2": "y"
-    }
-  },
-  sfr: {
-    desktop-webmail: {
-      "2021-02":"u"
-    },
-    ios: {
-      "2021-02":"u"
-    },
-    android: {
-      "2021-02":"u"
-    }
-  },
-  thunderbird: {
-    macos: {
-      "2021-02": "y"
-    }
-  },
-  protonmail: {
-    desktop-webmail: {
-      "2021-02":"u"
-    },
-    ios: {
-      "2021-02":"u"
-    },
-    android: {
-      "2021-02":"u"
-    }
-  },
-  hey: {
-    desktop-webmail: {
-      "2021-02":"u"
-    }
-  },
-  mail-ru: {
-    desktop-webmail: {
-      "2021-02":"a #1 #2"
-    }
-  }
+	apple-mail: {
+		macos: {
+			"11": "n",
+			"12": "n",
+			"13": "y"
+		},
+		ios: {
+			"11": "n",
+			"12": "n",
+			"13": "n",
+			"14": "y"
+		}
+	},
+	gmail: {
+		desktop-webmail: {
+			"2021-02": "n"
+		},
+		ios: {
+			"2021-02": "n"
+		},
+		android: {
+			"2021-02": "n"
+		},
+		mobile-webmail: {
+			"2021-02": "n"
+		}
+	},
+	orange: {
+		desktop-webmail: {
+			"2021-03":"y"
+		},
+		ios: {
+			"2021-03":"y"
+		},
+		android: {
+			"2021-03":"y"
+		}
+	},
+	outlook: {
+		windows: {
+			"2007": "n",
+			"2010": "n",
+			"2013": "n",
+			"2016": "n",
+			"2019": "n"
+		},
+		windows-10-mail: {
+			"2021-02": "n"
+		},
+		macos: {
+			"2011": "n",
+			"2016": "n",
+			"2021-02": "y"
+		},
+		outlook-com: {
+			"2021-02": "n"
+		},
+		ios: {
+			"2021-02": "n"
+		},
+		android: {
+			"4.2101.1": "n"
+		}
+	},
+	yahoo: {
+		desktop-webmail: {
+			"2021-02": "n"
+		},
+		ios: {
+			"2021-03":"n"
+		},
+		android: {
+			"6.16.2.1525679": "n"
+		}
+	},
+	aol: {
+		desktop-webmail: {
+			"2021-02": "n"
+		},
+		ios: {
+			"2021-03":"n"
+		},
+		android: {
+			"2021-03":"n"
+		}
+	},
+	samsung-email: {
+		android: {
+			"6.1.31.2": "y"
+		}
+	},
+	sfr: {
+		desktop-webmail: {
+			"2021-03":"y"
+		},
+		ios: {
+			"2021-03":"y"
+		},
+		android: {
+			"2021-03":"y"
+		}
+	},
+	thunderbird: {
+		macos: {
+			"2021-02": "y"
+		}
+	},
+	protonmail: {
+		desktop-webmail: {
+			"2021-03":"y"
+		},
+		ios: {
+			"2021-03":"y"
+		},
+		android: {
+			"2021-03":"y"
+		}
+	},
+	hey: {
+		desktop-webmail: {
+			"2021-03":"y"
+		}
+	},
+	mail-ru: {
+		desktop-webmail: {
+			"2021-02":"a #1 #2"
+		}
+	}
 }
 notes_by_num: {
-  "1": "Partial. `path()` is not supported.",
-  "2": "Partial. [Embeded SVG](/features/html-svg/) is not supported. Referencing an embeded SVG's `<clipPath>` with `url()` does not work.",
-  "3": "Partial. Referencing an external SVG's `<clipPath>` with `url()` does not work.",
+	"1": "Partial. `path()` is not supported.",
+	"2": "Partial. [Embedded SVG](/features/html-svg/) is not supported. Referencing an embedded SVG's `<clipPath>` with `url()` does not work.",
+	"3": "Partial. Referencing an external SVG's `<clipPath>` with `url()` does not work.",
 }
 links: {
-  "MDN: clip-path":"https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path",
-  "Can I use: CSS clip-path property (for HTML)":"https://caniuse.com/css-clip-path",
-  "Can I use: CSS property: clip-path: On HTML elements":"https://caniuse.com/mdn-css_properties_clip-path_html",
-  "Can I use: CSS property: clip-path: `path()`":"https://caniuse.com/mdn-css_properties_clip-path_path",
-  "Can I use: CSS property: clip-path: `<basic-shape>`":"https://caniuse.com/mdn-css_properties_clip-path_basic_shape",
-  "Can I use: SVG element: clipPath":"https://caniuse.com/mdn-svg_elements_clippath"
+	"MDN: clip-path":"https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path",
+	"Can I use: CSS clip-path property (for HTML)":"https://caniuse.com/css-clip-path",
+	"Can I use: CSS property: clip-path: On HTML elements":"https://caniuse.com/mdn-css_properties_clip-path_html",
+	"Can I use: CSS property: clip-path: `path()`":"https://caniuse.com/mdn-css_properties_clip-path_path",
+	"Can I use: CSS property: clip-path: `<basic-shape>`":"https://caniuse.com/mdn-css_properties_clip-path_basic_shape",
+	"Can I use: SVG element: clipPath":"https://caniuse.com/mdn-svg_elements_clippath"
 }
 ---

--- a/_features/css-clip-path.md
+++ b/_features/css-clip-path.md
@@ -1,0 +1,152 @@
+---
+title: "clip-path"
+description: ""
+category: css
+keywords: clip,path,svg,mask
+last_test_date: "2021-02-01"
+test_url: "/tests/css-clip-path.html"
+test_results_url: "https://testi.at/proj/OgBCZJIoG0CGNDFrYGTx5L"
+stats: {
+  apple-mail: {
+    macos: {
+      "11": "n",
+      "12": "n",
+      "13": "y"
+    },
+    ios: {
+      "11": "n",
+      "12": "n",
+      "13": "n",
+      "14": "y"
+    }
+  },
+  gmail: {
+    desktop-webmail: {
+      "2021-02": "n"
+    },
+    ios: {
+      "2021-02": "n"
+    },
+    android: {
+      "2021-02": "n"
+    },
+    mobile-webmail: {
+      "2021-02": "n"
+    }
+  },
+  orange: {
+    desktop-webmail: {
+      "2021-02":"u"
+    },
+    ios: {
+      "2021-02":"u"
+    },
+    android: {
+      "2021-02":"u"
+    }
+  },
+  outlook: {
+    windows: {
+      "2007": "n",
+      "2010": "n",
+      "2013": "n",
+      "2016": "n",
+      "2019": "n"
+    },
+    windows-10-mail: {
+      "2021-02": "n"
+    },
+    macos: {
+      "2011": "n",
+      "2016": "n",
+      "2021-02": "y"
+    },
+    outlook-com: {
+      "2021-02": "n"
+    },
+    ios: {
+      "2021-02": "n"
+    },
+    android: {
+      "4.2101.1": "n"
+    }
+  },
+  yahoo: {
+    desktop-webmail: {
+      "2021-02": "n"
+    },
+    ios: {
+      "2021-02": "u"
+    },
+    android: {
+      "6.16.2.1525679": "n"
+    }
+  },
+  aol: {
+    desktop-webmail: {
+      "2021-02": "n"
+    },
+    ios: {
+      "2021-02": "u"
+    },
+    android: {
+      "2021-02": "u"
+    }
+  },
+  samsung-email: {
+    android: {
+      "6.1.31.2": "n"
+    }
+  },
+  sfr: {
+    desktop-webmail: {
+      "2021-02":"u"
+    },
+    ios: {
+      "2021-02":"u"
+    },
+    android: {
+      "2021-02":"u"
+    }
+  },
+  thunderbird: {
+    macos: {
+      "2021-02": "y"
+    }
+  },
+  protonmail: {
+    desktop-webmail: {
+      "2021-02":"u"
+    },
+    ios: {
+      "2021-02":"u"
+    },
+    android: {
+      "2021-02":"u"
+    }
+  },
+  hey: {
+    desktop-webmail: {
+      "2021-02":"u"
+    }
+  },
+  mail-ru: {
+    desktop-webmail: {
+      "2021-02":"a #1 #2"
+    }
+  }
+}
+notes_by_num: {
+  "1": "Partial. `path()` is not supported.",
+  "2": "Partial. [Embeded SVG](/features/html-svg/) is not supported. Referencing an embeded SVG's `<clipPath>` with `url()` does not work.",
+  "3": "Partial. Referencing an external SVG's `<clipPath>` with `url()` does not work.",
+}
+links: {
+  "MDN: clip-path":"https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path",
+  "Can I use: CSS clip-path property (for HTML)":"https://caniuse.com/css-clip-path",
+  "Can I use: CSS property: clip-path: On HTML elements":"https://caniuse.com/mdn-css_properties_clip-path_html",
+  "Can I use: CSS property: clip-path: `path()`":"https://caniuse.com/mdn-css_properties_clip-path_path",
+  "Can I use: CSS property: clip-path: `<basic-shape>`":"https://caniuse.com/mdn-css_properties_clip-path_basic_shape",
+  "Can I use: SVG element: clipPath":"https://caniuse.com/mdn-svg_elements_clippath"
+}
+---

--- a/_features/css-clip-path.md
+++ b/_features/css-clip-path.md
@@ -95,7 +95,7 @@ stats: {
   },
   samsung-email: {
     android: {
-      "6.1.31.2": "n"
+      "6.1.31.2": "y"
     }
   },
   sfr: {

--- a/tests/css-clip-path.html
+++ b/tests/css-clip-path.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>clip-path</title>
+</head>
+<body>
+  <img src="https://interactive-examples.mdn.mozilla.net/media/examples/balloon-small.jpg" width="150" style="clip-path: circle(40% at 50% 50%);">
+  <img src="https://interactive-examples.mdn.mozilla.net/media/examples/balloon-small.jpg" width="150" style="clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);">
+  <img src="https://interactive-examples.mdn.mozilla.net/media/examples/balloon-small.jpg" width="150" style="clip-path: path('M 0 200 L 0,75 A 5,5 0,0,1 150,75 L 200 200 z');">
+
+  <div style="margin-top:40px;">
+    <img src="https://interactive-examples.mdn.mozilla.net/media/examples/balloon-small.jpg" width="150" style="clip-path: url(#myClip);">
+  
+    <svg width="150" height="180">
+      <defs>
+          <clipPath id="myClip">
+              <rect x="0" y="0" stroke="#000000" stroke-miterlimit="10" width="10" height="80"/>
+              <rect x="30" y="30" stroke="#000000" stroke-miterlimit="10" width="55" height="60"/>
+          </clipPath>
+      </defs>
+    </svg>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a test and the test data for the [clip-path CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path). Closes #109 

This does not include a test for external SVG with `url()`, which is [only supported in Firefox](https://caniuse.com/css-clip-path) at the moment. Perhaps me marking this as supported in some email clients is misleading? 