### PR TITLE
CSS caption-side

### DIFF
--- a/_features/css-caption-side.md
+++ b/_features/css-caption-side.md
@@ -1,0 +1,142 @@
+---
+title: "caption-side"
+description: "The `caption-side` CSS property puts the content of a table's `<caption>` on the specified side."
+category: css
+keywords: caption,table
+last_test_date: "2021-05-08"
+test_url: "/tests/css-caption-side.html"
+test_results_url: "https://testi.at/proj/JOOcrJZc0YcjDSZQRFP0OTlYXcw"
+stats: {
+	apple-mail: {
+		macos: {
+			"11": "y",
+			"12": "y",
+			"13": "y"
+		},
+		ios: {
+			"11": "y",
+			"12": "y",
+			"13": "y",
+			"14": "y"
+		}
+	},
+	gmail: {
+		desktop-webmail: {
+			"2021-05": "y"
+		},
+		ios: {
+			"2021-05": "y"
+		},
+		android: {
+			"2021-05": "y"
+		},
+		mobile-webmail: {
+			"2021-05": "y"
+		}
+	},
+	orange: {
+		desktop-webmail: {
+			"2021-05":"y"
+		},
+		ios: {
+			"2021-05":"u"
+		},
+		android: {
+			"2021-05":"u"
+		}
+	},
+	outlook: {
+		windows: {
+			"2007": "n",
+			"2010": "n",
+			"2013": "n",
+			"2016": "n",
+			"2019": "n"
+		},
+		windows-10-mail: {
+			"2021-05": "n"
+		},
+		macos: {
+			"2021-05": "y"
+		},
+		outlook-com: {
+			"2021-05": "n"
+		},
+		ios: {
+			"2021-05": "n"
+		},
+		android: {
+			"2021-05": "n"
+		}
+	},
+	yahoo: {
+		desktop-webmail: {
+			"2021-05": "y"
+		},
+		ios: {
+			"2021-05": "u"
+		},
+		android: {
+			"6.27.0.1549700": "y"
+		}
+	},
+	aol: {
+		desktop-webmail: {
+			"2021-05": "y"
+		},
+		ios: {
+			"2021-05": "y"
+		},
+		android: {
+			"2021-05": "y"
+		}
+	},
+	samsung-email: {
+		android: {
+			"6.1.42.0": "y"
+		}
+	},
+	sfr: {
+		desktop-webmail: {
+			"2021-05":"u"
+		},
+		ios: {
+			"2021-05":"u"
+		},
+		android: {
+			"2021-05":"u"
+		}
+	},
+	thunderbird: {
+		macos: {
+			"2021-05": "y"
+		}
+	},
+	protonmail: {
+		desktop-webmail: {
+			"2021-05":"u"
+		},
+		ios: {
+			"2021-05":"u"
+		},
+		android: {
+			"2021-05":"u"
+		}
+	},
+	hey: {
+		desktop-webmail: {
+			"2021-05":"u"
+		}
+	},
+	mail-ru: {
+		desktop-webmail: {
+			"2021-05":"n"
+		}
+	}
+}
+notes_by_num: {}
+links: {
+	"MDN: The Table Caption element":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption",
+	"MDN: caption-side":"https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side"
+}
+---

--- a/_features/css-caption-side.md
+++ b/_features/css-caption-side.md
@@ -39,10 +39,10 @@ stats: {
 			"2021-05":"y"
 		},
 		ios: {
-			"2021-05":"u"
+			"2021-05":"y"
 		},
 		android: {
-			"2021-05":"u"
+			"2021-05":"y"
 		}
 	},
 	outlook: {
@@ -60,13 +60,13 @@ stats: {
 			"2021-05": "y"
 		},
 		outlook-com: {
-			"2021-05": "n"
+			"2021-05": "y"
 		},
 		ios: {
-			"2021-05": "n"
+			"2021-05": "y"
 		},
 		android: {
-			"2021-05": "n"
+			"2021-05": "y"
 		}
 	},
 	yahoo: {
@@ -74,10 +74,10 @@ stats: {
 			"2021-05": "y"
 		},
 		ios: {
-			"2021-05": "u"
+			"2021-05": "y"
 		},
 		android: {
-			"6.27.0.1549700": "y"
+			"6.27": "y"
 		}
 	},
 	aol: {
@@ -98,13 +98,13 @@ stats: {
 	},
 	sfr: {
 		desktop-webmail: {
-			"2021-05":"u"
+			"2021-05":"y"
 		},
 		ios: {
-			"2021-05":"u"
+			"2021-05":"y"
 		},
 		android: {
-			"2021-05":"u"
+			"2021-05":"y"
 		}
 	},
 	thunderbird: {
@@ -114,27 +114,29 @@ stats: {
 	},
 	protonmail: {
 		desktop-webmail: {
-			"2021-05":"u"
+			"2021-05":"y"
 		},
 		ios: {
-			"2021-05":"u"
+			"2021-05":"y"
 		},
 		android: {
-			"2021-05":"u"
+			"2021-05":"y"
 		}
 	},
 	hey: {
 		desktop-webmail: {
-			"2021-05":"u"
+			"2021-05":"y #1"
 		}
 	},
 	mail-ru: {
 		desktop-webmail: {
-			"2021-05":"n"
+			"2021-05":"y #1"
 		}
 	}
 }
-notes_by_num: {}
+notes_by_num: {
+	"1": "The `caption-side` property in CSS is supported but the `<caption>` HTML element is not."
+}
 links: {
 	"MDN: The Table Caption element":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption",
 	"MDN: caption-side":"https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side"

--- a/tests/css-caption-side.html
+++ b/tests/css-caption-side.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>CSS caption-side</title>
+</head>
+<body>
+	<div style="text-align:center;">
+		<h2>caption-side:top</h2>
+		<table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100" style="caption-side:top; width:100%;">
+			<caption>caption</caption>
+			<tbody>
+				<tr>
+					<td>
+						Table body
+					</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<hr>
+
+		<h2>caption-side:top, caption placed after tbody</h2>
+		<table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100" style="caption-side:top; width:100%;">
+			<tbody>
+				<tr>
+					<td>
+						Table body
+					</td>
+				</tr>
+			</tbody>
+			<caption>caption</caption>
+		</table>
+
+		<hr>
+
+		<h2>caption-side:bottom</h2>
+		<table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100" style="caption-side:bottom; width:100%;">
+			<caption>caption</caption>
+			<tbody>
+				<tr>
+					<td>
+						Table body
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a test and the test data for the [caption-side CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side).

I excluded logical values (e.g. `block-end`) as I don't think these are supported in browsers yet.

The test also includes an example where the `<caption>` element is not the first child of the parent `<table>` (according to the spec it should be).