### PR TITLE
Keep only one tab in history per search, instead of one per character typed in

### DIFF
--- a/_js/_search.js
+++ b/_js/_search.js
@@ -74,7 +74,7 @@ class Search {
 			this.removeResultsMessage();
 			this.removeResultsContainer();
 			this.results = [];
-			history.pushState({id:'search'}, 'search', `${this.origin}`);
+			history.replaceState({id:'search'}, 'search', `${this.origin}`);
 		}
 
 		if(this.data && this.term) {
@@ -257,7 +257,7 @@ class Search {
 	}
 
 	updateURL() {
-		history.pushState({id:'search'}, 'search', `${document.location.origin}/search/?s=${encodeURIComponent(this.term)}`);
+		history.replaceState({id:'search'}, 'search', `${document.location.origin}/search/?s=${encodeURIComponent(this.term)}`);
 	}
 
 	updateTitle() {


### PR DESCRIPTION
Based on the comment by [larsnystrom in HackerNews](https://news.ycombinator.com/item?id=27112960#27114834), this fixes the problem of creating multiple tabs/entries in the browser history as the user types in to search.

I've tested it locally and it works fine.

The contributing guidelines in the repo only mentions adding to the list of un/supported HTML or CSS features, so let me know if this PR should be in a different form.