### PR TITLE
CSS box-shadow: updated test and results

### DIFF
--- a/_features/css-box-shadow.md
+++ b/_features/css-box-shadow.md
@@ -2,9 +2,9 @@
 title: "box-shadow"
 description: ""
 category: css
-last_test_date: "2019-02-28"
-test_url: "/tests/css-box-model.html"
-test_results_url: "https://app.emailonacid.com/app/acidtest/pyPQFHSYLFrhbRShalju0B2fYNwUgLuyKTLx4MLqiw5mE/list"
+last_test_date: "2021-08-03"
+test_url: "/tests/css-box-shadow.html"
+test_results_url: "https://testi.at/proj/po0Imx6tAX0U9bum5DTNpWcJ"
 stats: {
 	apple-mail: {
 		macos: {
@@ -22,7 +22,7 @@ stats: {
 			"2019-02":	"n"
 		},
 		android: {
-			"2019-02":	"n"
+			"2021-08":	"a #1"
 		},
         mobile-webmail: {
             "2020-02":"n"
@@ -88,7 +88,8 @@ stats: {
 	},
 	samsung-email: {
 		android: {
-			"5.0.10.2":	"y"
+			"5.0.10.2":	"y",
+			"6.1.50.25":	"y",
 		}
 	},
     sfr: {
@@ -133,5 +134,12 @@ stats: {
 			"2021-07": "y"
 		}
 	}
+}
+notes_by_num: {
+  "1": "Partial. Works with non-Gmail accounts (GANGA)."
+}
+links: {
+	"Can I use: CSS3 Box-shadow":"https://caniuse.com/css-boxshadow",
+	"MDN: box-shadow":"https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow"
 }
 ---

--- a/_features/css-box-shadow.md
+++ b/_features/css-box-shadow.md
@@ -19,7 +19,7 @@ stats: {
 			"2019-02":	"n"
 		},
 		ios: {
-			"2019-02":	"n"
+			"2019-02":	"a #1"
 		},
 		android: {
 			"2021-08":	"a #1"
@@ -136,7 +136,7 @@ stats: {
 	}
 }
 notes_by_num: {
-  "1": "Partial. Works with non-Gmail accounts (GANGA)."
+  "1": "Partial. Only supported with non Gmail accounts."
 }
 links: {
 	"Can I use: CSS3 Box-shadow":"https://caniuse.com/css-boxshadow",

--- a/tests/css-box-shadow.html
+++ b/tests/css-box-shadow.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head></head>
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS box-shadow</title>
+</head>
+
+<body>
+  <div style="padding:20px;">
+    <h2>Basic values</h2>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px #04f84d;">
+      <p>offset-x (positive value, px) | offset-y (positive value, px) | color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:-20px -10px #04f84d;">
+      <p>offset-x (negative value, px) | offset-y (negative value, px) | color color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px rgb(4, 248, 77);">
+      <p>offset-x (positive value, px) | offset-y (positive value, px) | color (rgb)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px rgb(4, 248, 77, 0.5);">
+      <p>offset-x (positive value, px) | offset-y (positive value, px) | color (rgb with opacity)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px hsl(138, 97%, 49%);">
+      <p>offset-x (positive value, px) | offset-y (positive value, px) | color (hsl)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px hsl(138, 97%, 49%, 0.5);">
+      <p>offset-x (positive value, px) | offset-y (positive value, px) | color (hsl with opacity)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:0.6em 1em #04f84d;">
+      <p>offset-x (positive value, em) | offset-y (positive value, em) | color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:-0.6em -1em #04f84d;">
+      <p>offset-x (negative value, em) | offset-y (negative value, em) | color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:0.6rem 1rem #04f84d;">
+      <p>offset-x (positive value, rem) | offset-y (positive value, rem) | color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:-0.6rem -1rem #04f84d;">
+      <p>offset-x (negative value, rem) | offset-y (negative value, rem) | color (6-char hex)</p>
+    </div>
+
+
+    <hr>
+
+    <h2>With blur</h2>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px 5px #04f84d;">
+      <p>offset-x (positive value, px) | offset-y (positive value, px) | blur-radius (px) | color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px 1em #04f84d;">
+      <p>offset-x (positive value, px) | offset-y (positive value, px) | blur-radius (em) | color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px 1rem #04f84d;">
+      <p>offset-x (positive value, px) | offset-y (positive value, px) | blur-radius (rem) | color (6-char hex)</p>
+    </div>
+
+
+    <hr>
+
+    <h2>With spread</h2>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px 5px 15px #04f84d;">
+      <p>offset-x (positive value, px) | offset-y (positive value, px) | blur-radius (px) | spread-radius (px) | color (6-char hex)</p>
+    </div>
+
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 40px 5px -15px #04f84d;">
+      <p>offset-x (positive value, px) | offset-y (positive value, px) | blur-radius (px) | spread-radius (negative value, px) | color (6-char hex)</p>
+    </div>
+
+
+    <hr>
+
+    <h2>With inset</h2>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:inset 20px 10px #04f84d;">
+      <p>inset | offset-x (positive value, px) | offset-y (positive value, px) | color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:inset -20px -10px #04f84d;">
+      <p>inset | offset-x (negative value, px) | offset-y (negative value, px) | color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:inset 20px 10px 5px #04f84d;">
+      <p>inset | offset-x (positive value, px) | offset-y (positive value, px) | blur-radius (px) | color (6-char hex)</p>
+    </div>
+
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:inset 20px 10px 5px 15px #04f84d;">
+      <p>inset | offset-x (positive value, px) | offset-y (positive value, px) | blur-radius (px) | spread-radius (px) | color (6-char hex)</p>
+    </div>
+
+
+    <hr>
+
+    <h2>Multiple shadows</h2>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px #04f84d, 40px 30px #041cf8;">
+      <p>Multiple (2): offset-x (positive value, px) | offset-y (positive value, px) | color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:20px 10px #04f84d, 40px 30px #041cf8, 10px 40px #cbf804;">
+      <p>Multiple (3): offset-x (positive value, px) | offset-y (positive value, px) | color (6-char hex)</p>
+    </div>
+
+    <div style="background-color:#ee8080; padding:20px; margin:60px 0; box-shadow:inset 20px 10px #04f84d, 40px 20px 5px #041cf8;">
+      <p>Multiple (2): mixed values</p>
+    </div>
+
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
Hi,

This PR adds a separate test for the box-shadow CSS property and updates the results. 

The previous test was within [tests/css-box-model](https://github.com/hteumeuleu/caniemail/blob/master/tests/css-box-model.html). Reasons for creating a separate test:

- Test various values, units and syntaxes
- Easier to expand the test with other values as needed
- [tests/css-box-model](https://github.com/hteumeuleu/caniemail/blob/master/tests/css-box-model.html) relies on embedded CSS which does not work in GANGA


Notes:

- I have not tested this on GANGA iOS
- Testi@ now includes iPhone 12 iOS 14 (force dark). I don't know how this differs from normal dark mode or how a normal user can set their Apple Mail app to this mode. According to Testi@'s [changelog](https://testi.at/changelog), they're adding the class `.apple-mail-implicit-dark-support` to the `<html>` tag.
- I have not added this to the notes, but it seems on versions older than iOS 12, Apple Mail do not support color values with alpha values (when using `rgb()` and `hsl()`). I think this behaviour is not specific to `box-shadow` and applies to `rgb()` and `hsl()` values in general. So it's probably more appropriate to add this note to the [rgb() page](https://www.caniemail.com/features/css-rgb/) and the hsl() page.