### PR TITLE
Image maps feature and test page

### DIFF
--- a/_features/html-image-maps.md
+++ b/_features/html-image-maps.md
@@ -1,0 +1,144 @@
+---
+title: "Image maps"
+description: "`<img>` with a `usemap` attribute and associated `<map>` with a `name` attribute and descendant `<area>` elements define a client-side image map."
+category: html
+keywords: image maps, map element, area element, usemap attribute
+last_test_date: ""
+test_url: "/tests/html-image-maps.html"
+test_results_url: ""
+stats: {
+    apple-mail: {
+        macos: {
+            "13":"u"
+        },
+        ios: {
+            "13":"u"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2020-09":"u"
+        },
+        ios: {
+            "2020-09":"u"
+        },
+        android: {
+            "2020-09":"u"
+        },
+        mobile-webmail: {
+            "2020-09":"u"
+        }
+    },
+    orange: {
+        desktop-webmail: {
+            "2020-09":"u"
+        },
+        ios: {
+            "2020-09":"u"
+        },
+        android: {
+            "2020-09":"u"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"u",
+            "2007":"u",
+            "2010":"u",
+            "2013":"u",
+            "2016":"u",
+            "2019":"u"
+        },
+        windows-10-mail: {
+            "2020-09":"u"
+        },
+        macos: {
+            "2011":"u",
+            "2016":"u"
+        },
+        outlook-com: {
+            "2020-09":"u"
+        },
+        ios: {
+            "2020-09":"u"
+        },
+        android: {
+            "2020-09":"u"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.0":"u"
+        }
+    },
+    sfr: {
+        desktop-webmail: {
+            "2020-09":"u"
+        },
+        ios: {
+            "2020-09":"u"
+        },
+        android: {
+            "2020-09":"u"
+        }
+    },
+    thunderbird: {
+        macos: {
+            "68.7":"u"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2020-09":"u"
+        },
+        ios: {
+            "2020-09":"u"
+        },
+        android: {
+            "2020-09":"u"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2020-09":"u"
+        },
+        ios: {
+            "2020-09":"u"
+        },
+        android: {
+            "2020-09":"u"
+        }
+    },
+    protonmail: {
+        desktop-webmail: {
+            "2020-09":"u"
+        },
+        ios: {
+            "2020-09":"u"
+        },
+        android: {
+            "2020-09":"u"
+        }
+    },
+    hey: {
+        desktop-webmail: {
+            "2020-09":"u"
+        }
+    },
+    mail-ru: {
+        desktop-webmail: {
+            "2020-09":"u"
+        }
+    },
+    fastmail: {
+        desktop-webmail: {
+            "2021-07": "u"
+        }
+    }
+}
+links: {
+    "HTML: image maps":"https://html.spec.whatwg.org/multipage/image-maps.html#image-maps",
+    "MDN: map element":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map",
+    "MDN: area element":"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area"
+}
+---

--- a/tests/html-image-maps.html
+++ b/tests/html-image-maps.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="x-apple-disable-message-reformatting">
+  <!--[if mso]>
+  <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+  </xml>
+  <![endif]-->
+  <title>HTML Image maps</title>
+</head>
+<body>
+  <map name="map">
+    <area shape="circle" coords="256,256,256" href="https://maps4html.org" target="_blank" alt="Maps for HTML Community Group">
+  </map>
+  <img usemap="#map" src="https://maps4html.org/assets/maps4html_512x512.png" width="512" height="512" alt="Maps4HTML">
+</body>
+</html>


### PR DESCRIPTION
Adds HTML image maps as requested in https://github.com/hteumeuleu/caniemail/issues/181.

@hteumeuleu I've never done email testing to the extent required in this project, can this feature be added without any tests done yet? Should https://github.com/hteumeuleu/caniemail/issues/181 stay open as a way to say "help wanted" with tests?