### PR TITLE
`<audio>`: fix typo in note on CSP issue

### DIFF
--- a/_features/html-audio.md
+++ b/_features/html-audio.md
@@ -152,7 +152,7 @@ notes_by_num: {
     "1": "Does not play.",
     "2": "The `src` attribute is transformed into `proton-src`.",
     "3": "The `<audio>` element is supported but can not be played.",
-    "4": "The `<audio>` element is supported, but the video can not play due to a strict Content Security Policy.",
+    "4": "The `<audio>` element is supported, but the audio can not play due to a strict Content Security Policy.",
     "5": "Not supported. The `<audio>` element and all its content is removed."
 }
 ---


### PR DESCRIPTION
Looks like a typo, or copy paste error from the `<video>` feature.