### PR TITLE
CSS property text-align 

### DIFF
--- a/_features/css-text-align.md
+++ b/_features/css-text-align.md
@@ -1,0 +1,148 @@
+---
+title: "text-align"
+description: "The `text-align` CSS property"
+category: css
+keywords: align
+last_test_date: "2021-09-24"
+test_url: "/tests/css-text-align.html"
+test_results_url: "https://testi.at/proj/G4YtBn8fBxEsLx6uybqcxD"
+stats: {
+	apple-mail: {
+		macos: {
+			"2021-09": "y"
+		},
+		ios: {
+			"11": "y",
+			"12": "y",
+			"13": "y",
+			"14": "y"
+		}
+	},
+	gmail: {
+		desktop-webmail: {
+			"2021-09": "y"
+		},
+		ios: {
+			"2021-09": "a #2"
+		},
+		android: {
+			"2021-09": "a #2"
+		},
+		mobile-webmail: {
+			"2021-09": "y"
+		}
+	},
+	orange: {
+		desktop-webmail: {
+			"2021-09":"u"
+		},
+		ios: {
+			"2021-09":"u"
+		},
+		android: {
+			"2021-09":"u"
+		}
+	},
+	outlook: {
+		windows: {
+			"2007": "a #1",
+			"2010": "a #1",
+			"2013": "a #1",
+			"2016": "a #1",
+			"2019": "a #1"
+		},
+		windows-10-mail: {
+			"2021-09": "a #1"
+		},
+		macos: {
+			"2021-09": "y"
+		},
+		outlook-com: {
+			"2021-09": "y"
+		},
+		ios: {
+			"2021-09": "y"
+		},
+		android: {
+			"2021-09": "y"
+		}
+	},
+	yahoo: {
+		desktop-webmail: {
+			"2021-09": "a #1"
+		},
+		ios: {
+			"2021-09": "u"
+		},
+		android: {
+			"6.37": "a #1"
+		}
+	},
+	aol: {
+		desktop-webmail: {
+			"2021-09": "a #1"
+		},
+		ios: {
+			"2021-09": "u"
+		},
+		android: {
+			"2021-09": "u"
+		}
+	},
+	samsung-email: {
+		android: {
+			"6.1.51.1": "y"
+		}
+	},
+	sfr: {
+		desktop-webmail: {
+			"2021-09":"y"
+		},
+		ios: {
+			"2021-09":"y"
+		},
+		android: {
+			"2021-09":"y"
+		}
+	},
+	thunderbird: {
+		macos: {
+			"2021-09": "y"
+		}
+	},
+	protonmail: {
+		desktop-webmail: {
+			"2021-09":"u"
+		},
+		ios: {
+			"2021-09":"u"
+		},
+		android: {
+			"2021-09":"u"
+		}
+	},
+	hey: {
+		desktop-webmail: {
+			"2021-09":"u"
+		}
+	},
+	mail-ru: {
+		desktop-webmail: {
+			"2021-09":"y"
+		}
+	},
+	fastmail: {
+		desktop-webmail: {
+			"2021-07": "u"
+		}
+	}
+}
+notes_by_num: {
+	"1": "Partial. Flow-relative values `start` and `end` are not supported",
+	"2": "Partial. Flow-relative values `start` and `end` are not supported with non Gmail account"
+}
+links: {
+	"MDN: The text-align CSS property":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-align",
+	"Can I use: CSS property: text-align: Flow-relative values `start` and `end`:"https://caniuse.com/mdn-css_properties_text-align_flow_relative_values_start_and_end"
+}
+---

--- a/tests/css-text-align.html
+++ b/tests/css-text-align.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <style>
+    code {
+      color: red;
+    }
+  </style>
+</head>
+<body>
+<div style="padding:30px; max-width:400px;">
+<!--[if mso]>
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="400" align="center" style="border-spacing:0;">
+    <tr>
+      <td>
+<![endif]-->
+  <p style="border:1px solid; padding:12px; text-align:left;">
+    <code>text-align:left;</code><br>
+    Integer elementum massa at nulla placerat varius.
+    Suspendisse in libero risus, in interdum massa.
+    Vestibulum ac leo vitae metus faucibus gravida ac in neque.
+    Nullam est eros, suscipit sed dictum quis, accumsan a ligula.
+  </p>
+
+  <p style="border:1px solid; padding:12px; text-align:right;">
+    <code>text-align:right;</code><br>
+    Integer elementum massa at nulla placerat varius.
+    Suspendisse in libero risus, in interdum massa.
+    Vestibulum ac leo vitae metus faucibus gravida ac in neque.
+    Nullam est eros, suscipit sed dictum quis, accumsan a ligula.
+  </p>
+
+  <p style="border:1px solid; padding:12px; text-align:start;">
+    <code>text-align:start;</code><br>
+    Integer elementum massa at nulla placerat varius.
+    Suspendisse in libero risus, in interdum massa.
+    Vestibulum ac leo vitae metus faucibus gravida ac in neque.
+    Nullam est eros, suscipit sed dictum quis, accumsan a ligula.
+  </p>
+
+  <p style="border:1px solid; padding:12px; text-align:end;">
+    <code>text-align:end;</code><br>
+    Integer elementum massa at nulla placerat varius.
+    Suspendisse in libero risus, in interdum massa.
+    Vestibulum ac leo vitae metus faucibus gravida ac in neque.
+    Nullam est eros, suscipit sed dictum quis, accumsan a ligula.
+  </p>
+
+  <p style="border:1px solid; padding:12px; text-align:center;">
+    <code>text-align:center;</code><br>
+    Integer elementum massa at nulla placerat varius.
+    Suspendisse in libero risus, in interdum massa.
+    Vestibulum ac leo vitae metus faucibus gravida ac in neque.
+    Nullam est eros, suscipit sed dictum quis, accumsan a ligula.
+  </p>
+
+  <p style="border:1px solid; padding:12px; text-align:justify;">
+    <code>text-align:justify;</code><br>
+    Integer elementum massa at nulla placerat varius.
+    Suspendisse in libero risus, in interdum massa.
+    Vestibulum ac leo vitae metus faucibus gravida ac in neque.
+    Nullam est eros, suscipit sed dictum quis, accumsan a ligula.
+  </p>
+<!--[if mso]>
+    </td>
+  </tr>
+</table>
+<![endif]-->
+</div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a test and the test data for the [text-align CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align). Closes #129 

I left out the following values:
- `justify-all`: no browser support
- `<string>`: no browser support
- `match-parent`: we may need to test the `direction` CSS property before testing this