### PR TITLE
Update rgb() and rgba() data to indicate partial support

### DIFF
--- a/_features/css-rgb.md
+++ b/_features/css-rgb.md
@@ -155,6 +155,7 @@ links: {
   "Can I use: RGB functional notation (rgb())":"https://caniuse.com/mdn-css_types_color_rgb_functional_notation",
   "Can I use: rgb() can accept alpha values":"https://caniuse.com/mdn-css_types_color_rgb_function_accepts_alpha",
   "Can I use: Allow floats in rgb() and rgba()":"https://caniuse.com/mdn-css_types_color_floats_in_rgb_rgba",
-  "MDN: <color> CSS data type":"https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb()"
+  "MDN: <color> CSS data type":"https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb()",
+  "MDN: Browser compatibility for space-sparated values (also known as whitespace syntax)":"https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb()#space-separated_values"
 }
 ---

--- a/_features/css-rgba.md
+++ b/_features/css-rgba.md
@@ -151,6 +151,7 @@ notes_by_num: {
 links: {
   "Can I use: Alpha color values (rgba(), hsla())":"https://caniuse.com/mdn-css_types_color_alpha",
   "Can I use: Allow floats in rgb() and rgba()":"https://caniuse.com/mdn-css_types_color_floats_in_rgb_rgba",
-  "MDN: <color> CSS data type":"https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb()"
+  "MDN: <color> CSS data type":"https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb()",
+  "MDN: Browser compatibility for space-sparated values (also known as whitespace syntax)":"https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgba()#space-separated_values"
 }
 ---


### PR DESCRIPTION
This PR updates the data for the `rgb()` and `rgba()` functional notation to indicate partial support.