### PR TITLE
img[loading] test and data

### DIFF
--- a/_features/html-img-loading.md
+++ b/_features/html-img-loading.md
@@ -1,0 +1,154 @@
+---
+title: "img[loading]"
+description: "The `loading` attributes on `img` indicates how the browser should load the image"
+category: html
+keywords: img,image,loading
+last_test_date: "2021-10-27"
+test_url: "/tests/html-img-loading.html"
+test_results_url: "https://testi.at/proj/BG3iM7ZhOjpi8Qlf4E9IQxg"
+stats: {
+	apple-mail: {
+		macos: {
+			"2021-10": "a #1"
+		},
+		ios: {
+			"11": "a #1",
+			"12": "a #1",
+			"13": "a #1",
+			"14": "a #1"
+		}
+	},
+	gmail: {
+		desktop-webmail: {
+			"2021-10": "n"
+		},
+		ios: {
+			"2021-10": "n"
+		},
+		android: {
+			"2021-10": "n"
+		},
+		mobile-webmail: {
+			"2021-10": "u"
+		}
+	},
+	orange: {
+		desktop-webmail: {
+			"2021-10":"u"
+		},
+		ios: {
+			"2021-10":"u"
+		},
+		android: {
+			"2021-10":"u"
+		}
+	},
+	outlook: {
+		windows: {
+			"2007": "n",
+			"2010": "n",
+			"2013": "n",
+			"2016": "n",
+			"2019": "n"
+		},
+		windows-mail: {
+			"2021-10": "n"
+		},
+		macos: {
+			"2021-10": "y #1"
+		},
+		outlook-com: {
+			"2021-10": "n"
+		},
+		ios: {
+			"2021-10": "n"
+		},
+		android: {
+			"2021-10": "n"
+		}
+	},
+	yahoo: {
+		desktop-webmail: {
+			"2021-10": "n"
+		},
+		ios: {
+			"2021-10": "u"
+		},
+		android: {
+			"2021-10": "n"
+		}
+	},
+	aol: {
+		desktop-webmail: {
+			"2021-10": "n"
+		},
+		ios: {
+			"2021-10": "u"
+		},
+		android: {
+			"2021-10": "u"
+		}
+	},
+	samsung-email: {
+		android: {
+			"2021-10": "y #1"
+		}
+	},
+	sfr: {
+		desktop-webmail: {
+			"2021-10":"u"
+		},
+		ios: {
+			"2021-10":"u"
+		},
+		android: {
+			"2021-10":"u"
+		}
+	},
+	thunderbird: {
+		macos: {
+			"2021-10": "y #1"
+		}
+	},
+	protonmail: {
+		desktop-webmail: {
+			"2021-10":"u"
+		},
+		ios: {
+			"2021-10":"u"
+		},
+		android: {
+			"2021-10":"u"
+		}
+	},
+	hey: {
+		desktop-webmail: {
+			"2021-10":"u"
+		}
+	},
+	mail-ru: {
+		desktop-webmail: {
+			"2021-10":"y #1"
+		}
+	},
+	fastmail: {
+		desktop-webmail: {
+			"2021-07": "u"
+		}
+	},
+	laposte: {
+		desktop-webmail: {
+			"2021-10": "u"
+		}
+	}
+}
+notes_by_num: {
+  "1": "The `loading` attribute is supported, but not confirmed whether it works according to spec.",
+  "2": "The `loading` attribute is supported by the email client, but not by the browser engine."
+}
+links: {
+	"MDN: `loading` attribute on `<img>`": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading",
+	"MDN: lazy loading": "https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading",
+	"Can I use: Lazy loading via attribute for images & iframes": "https://caniuse.com/loading-lazy-attr"
+}
+---

--- a/tests/html-img-loading.html
+++ b/tests/html-img-loading.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head></head>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+
+  <style>
+    img[loading]+p {
+      display: block !important;
+    }
+
+    img[loading="lazy"]+p, img[loading="eager"]+p {
+      display: block !important;
+    }
+  </style>
+</head>
+<body>
+  <img src="https://via.placeholder.com/1200x675/FF0000/FFFFFF.png" alt="" width="640" height="360" loading="lazy" style="width:100%; height:auto;" />
+  <p style="display:none;">img[loading] & attribute selectors are supported</p>
+
+  <img src="https://via.placeholder.com/1200x675/FF0000/FFFFFF.png" alt="" width="640" height="360" loading="eager" style="width:100%; height:auto;" />
+  <p style="display:none;">img[loading] & attribute selectors are supported</p>
+  <p></p>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a basic test for the `loading` attribute on `<img>` and the relevant data.

The test really just allows us to see whether an email client keeps/strips the attribute, which doesn't necessarily indicate whether the feature works:

1. Some email clients use a browser engine that doesn't support this feature. It doesn't work in Safari, so it doesn't work on any email client on iOS.
2. I have no idea if any email clients prefetch images. So even though they keep the attribute, it may be redundant.


Better tests would get better and more definitive data, but I guess this is better than nothing!
