### PR TITLE
AMP: Gmail and Yahoo browser support

### DIFF
--- a/_features/amp.md
+++ b/_features/amp.md
@@ -16,7 +16,7 @@ stats: {
   },
   gmail: {
     desktop-webmail: {
-      "2020-04":"y"
+      "2022-02":"a #1"
     },
     ios: {
       "2020-04":"y"
@@ -67,7 +67,7 @@ stats: {
   yahoo: {
     desktop-webmail: {
       "2019-10":"n",
-	  "2021-01":"y"
+	  "2022-02":"a #1"
     },
     ios: {
       "2019-10":"n"
@@ -141,10 +141,13 @@ stats: {
   }
 }
 notes_by_num: {
+  "1": "Partial. Not supported on all compatible evergreen browsers. Refer to 'supported platforms' links listed below under resources."
 }
 links: {
   "AMP for Email Format":"https://amp.dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-format/?format=email",
   "Gmail documentation on AMP":"https://developers.google.com/gmail/ampemail",
-  "Mail.ru AMP emails":"https://postmaster.mail.ru/amp/?lang=en"
+  "Mail.ru AMP emails":"https://postmaster.mail.ru/amp/?lang=en",
+  "Gmail supported platforms":"https://developers.google.com/gmail/ampemail/supported-platforms",
+  "Yahoo supported platforms":"https://senders.yahooinc.com/amp/#supported-platforms"
 }
 ---

--- a/_features/amp.md
+++ b/_features/amp.md
@@ -16,6 +16,7 @@ stats: {
   },
   gmail: {
     desktop-webmail: {
+      "2020-04":"y",
       "2022-02":"a #1"
     },
     ios: {
@@ -24,9 +25,9 @@ stats: {
     android: {
       "2020-04":"y"
     },
-        mobile-webmail: {
-            "2020-04":"n"
-        }
+    mobile-webmail: {
+      "2020-04":"n"
+    }
   },
     orange: {
         desktop-webmail: {
@@ -67,6 +68,7 @@ stats: {
   yahoo: {
     desktop-webmail: {
       "2019-10":"n",
+	  "2021-01":"y",
 	  "2022-02":"a #1"
     },
     ios: {


### PR DESCRIPTION
This PR updates the listed support for AMP in Gmail and Yahoo desktop web mails. Neither email client supports AMP on (Chromium) Edge which is compatible. 

Mail.ru supports AMP on Edge, but it seems Gmail and Yahoo choose not to.

