### PR TITLE
Fix Jekyll frontmatter tags syntax

### DIFF
--- a/_features/html-picture.md
+++ b/_features/html-picture.md
@@ -3,7 +3,7 @@ title: "<picture> element"
 description: "This is the description of the `<picture>` element."
 category: html
 keywords: picture, responsive image
-tags: accessibility, performance
+tags: accessibility performance
 last_test_date: "2019-05-29"
 test_url: "/tests/html-picture.html"
 test_results_url: "https://app.emailonacid.com/app/acidtest/AQoLHTLaC6F6JcMrkx38M7oyiJlAlXeRnJgkK06bSJiBR/list"


### PR DESCRIPTION
This PR fixes the Jekyll tags syntax. 

According to the [Jekyll docs](https://jekyllrb.com/docs/posts/#tags-and-categories) the list of tags are separated by space not comma:

> Since Jekyll expects multiple items mapped to the key tags, it will automatically split a string entry if it contains whitespace. 

The comma in the value currently is part of the first tag. This is reflected in the [JSON data](https://www.caniemail.com/api/data.json): 

```json
{
  "slug":"html-picture",
  "title":"<picture> element",
  "description":"This is the description of the `<picture>` element.",
  "url":"https://www.caniemail.com/features/html-picture/",
  "category":"html",
  "tags":["accessibility,","performance"],
  "keywords":"picture, responsive image",
}
```