### PR TITLE
Tags: HTML `ruby`

### DIFF
--- a/_features/html-rp.md
+++ b/_features/html-rp.md
@@ -2,6 +2,7 @@
 title: "<rp> element"
 description: ""
 category:	html
+tags: i18n
 last_test_date: "2019-02-28"
 test_url: "/tests/HTML5.html"
 test_results_url: "https://app.emailonacid.com/app/acidtest/Bzyzx8Z5Kvlfib1Fw9Ted8xtPE26RcjPSdUobdUywgJVm/list"

--- a/_features/html-rt.md
+++ b/_features/html-rt.md
@@ -2,6 +2,7 @@
 title: "<rt> element"
 description: ""
 category: html
+tags: i18n
 last_test_date: "2019-02-28"
 test_url: "/tests/HTML5.html"
 test_results_url: "https://app.emailonacid.com/app/acidtest/Bzyzx8Z5Kvlfib1Fw9Ted8xtPE26RcjPSdUobdUywgJVm/list"

--- a/_features/html-ruby.md
+++ b/_features/html-ruby.md
@@ -2,6 +2,7 @@
 title: "<ruby> element"
 description: ""
 category: html
+tags: i18n
 last_test_date: "2019-02-28"
 test_url: "/tests/HTML5.html"
 test_results_url: "https://app.emailonacid.com/app/acidtest/Bzyzx8Z5Kvlfib1Fw9Ted8xtPE26RcjPSdUobdUywgJVm/list"


### PR DESCRIPTION
This PR adds feature categories to the `ruby`, `rp` and `rt` HTML elements as discussed in https://github.com/hteumeuleu/caniemail/issues/232

`i18n` is for internationalisation. Happy to change this to the full word.