### PR TITLE
Tags: HTML `lang` attribute

### DIFF
--- a/_features/html-lang.md
+++ b/_features/html-lang.md
@@ -2,6 +2,7 @@
 title: "lang attribute"
 description: "The `lang` attribute lets you declare the language of the content of an HTML element."
 category: html
+tags: i18n accessibility
 last_test_date: "2020-10-25"
 test_url: "/tests/html-lang.html"
 test_results_url: "https://app.emailonacid.com/app/acidtest/Cw4skDHvaihUbRGS21mmXSnyxfjIQQNAMGfRwXlpf6zR7/list"


### PR DESCRIPTION
This PR adds feature categories to the `lang` HTML attribute as discussed in https://github.com/hteumeuleu/caniemail/issues/232