### PR TITLE
Tags: `@media (prefers-reduced-motion)`

### DIFF
--- a/_features/css-at-media-prefers-reduced-motion.md
+++ b/_features/css-at-media-prefers-reduced-motion.md
@@ -3,6 +3,7 @@ title: "@media (prefers-reduced-motion)"
 description: ""
 category: css
 keywords: "media queries, media query, media feature, prefers-reduced-motion, animation, accessibility"
+tags: accessibility performance
 last_test_date: "2021-02-20"
 test_url: "/tests/css-media-prefers-reduced-motion.html"
 test_results_url: "https://testi.at/proj/e3GT3l1CxqBUoE3u9keC4WLf5"


### PR DESCRIPTION
This PR adds feature categories to the `prefers-reduced-motion` media query as discussed in https://github.com/hteumeuleu/caniemail/issues/232

Tagged as good for performance because you can choose not to load external resources (e.g. GIFs) if the user prefers reduced motion (background image or with the `picture` element). Users may also enable this preference to save battery life or when using less powerful devices.