### PR TITLE
Tags: CSS `list-style-type`

### DIFF
--- a/_features/css-list-style-type.md
+++ b/_features/css-list-style-type.md
@@ -1,6 +1,7 @@
 ---
 title: "list-style-type"
 category: css
+tags: i18n
 last_test_date: "2020-04-20"
 test_url: "/tests/css-list.html"
 test_results_url: "https://app.emailonacid.com/app/acidtest/ifwlqtEsBCU23xVI7NgjBqvJlcJ4c20Akv3aRW3ugRJsP/list"


### PR DESCRIPTION
This PR adds feature categories to the `list-style-type` CSS property as discussed in https://github.com/hteumeuleu/caniemail/issues/232

Tagged as good for interntationalisation because the `list-style-type` property accepts many values that cover different numeral systems. Example values:
- japanese-formal
- lower-greek
- arabic-indic