### PR TITLE
update results for thickness and offset

### DIFF
--- a/_features/css-text-decoration-thickness.md
+++ b/_features/css-text-decoration-thickness.md
@@ -2,7 +2,7 @@
 title: "text-decoration-thickness"
 category: css
 keywords: underline
-last_test_date: "2020-04-30"
+last_test_date: "2023-01-16"
 test_url: "/tests/css-text-decoration.html"
 test_results_url: "https://app.emailonacid.com/app/acidtest/VYmPi84Nw2pMoQLeljigICaH0QudjS2xc2CgpvPbEW7FZ/list"
 stats: {
@@ -17,13 +17,16 @@ stats: {
     },
     gmail: {
         desktop-webmail: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2023-01":"n"
         },
         ios: {
-            "2020-04":"n"
+            "2020-04":"n",
+            "2023-01":"n"
         },
         android: {
-            "2020-04":"n"
+            "2020-04":"n",
+            "2023-01":"n"
         },
         mobile-webmail: {
             "2020-04":"n"
@@ -55,21 +58,25 @@ stats: {
         },
         macos: {
             "2011":"n",
-            "2016":"n"
+            "2016":"n",
+            "2023-01":"y"
         },
         outlook-com: {
             "2020-04":"n"
         },
         ios: {
-            "2020-04":"n"
+            "2020-04":"n",
+            "2023-01":"n"
         },
         android: {
-            "2020-04":"n"
+            "2020-04":"n",
+            "2023-01":"n"
         }
     },
     samsung-email: {
         android: {
-            "7.0":"n"
+            "7.0":"n",
+            "10":"y"
         }
     },
     sfr: {
@@ -85,7 +92,8 @@ stats: {
     },
     thunderbird: {
         macos: {
-            "68.7":"n"
+            "68.7":"n",
+            "102.6":"y"
         }
     },
     aol: {
@@ -104,10 +112,12 @@ stats: {
             "2020-04":"n"
         },
         ios: {
-            "2020-04":"n"
+            "2020-04":"n",
+            "2023-01":"n"
         },
         android: {
-            "2020-04":"n"
+            "2020-04":"n",
+            "2023-01":"n"
         }
     },
     protonmail: {
@@ -118,7 +128,8 @@ stats: {
             "2020-04":"y"
         },
         android: {
-            "2020-04":"n"
+            "2020-04":"n",
+            "2023-01":"y"
         }
     },
     hey: {

--- a/_features/css-text-underline-offset.md
+++ b/_features/css-text-underline-offset.md
@@ -2,7 +2,7 @@
 title: "text-underline-offset"
 category: css
 keywords: underline
-last_test_date: "2021-01-20"
+last_test_date: "2023-01-16"
 test_url: "/tests/css-text-decoration.html"
 test_results_url: "https://app.emailonacid.com/app/acidtest/Zo8XyakhcacSbta8lYvU5vSTAWnaTLi7XIcWtQ7B218Cj/list"
 stats: {
@@ -16,13 +16,16 @@ stats: {
     },
     gmail: {
         desktop-webmail: {
-            "2021-01":"n"
+            "2021-01":"n",
+            "2023-01":"n"
         },
         ios: {
-            "2021-01":"n"
+            "2021-01":"n",
+            "2023-01":"n"
         },
         android: {
-            "2021-01":"n"
+            "2021-01":"n",
+            "2023-01":"n"
         },
         mobile-webmail: {
             "2021-01":"n"
@@ -60,10 +63,12 @@ stats: {
             "2021-01":"n"
         },
         ios: {
-            "2021-01":"n"
+            "2021-01":"n",
+            "2023-01":"n"
         },
         android: {
-            "2021-01":"n"
+            "2021-01":"n",
+            "2023-01":"n"
         }
     },
     samsung-email: {
@@ -103,10 +108,12 @@ stats: {
             "2021-01":"n"
         },
         ios: {
-            "2021-01":"n"
+            "2021-01":"n",
+            "2023-01":"n"
         },
         android: {
-            "2021-01":"n"
+            "2021-01":"n",
+            "2023-01":"n"
         }
     },
     protonmail: {
@@ -117,7 +124,8 @@ stats: {
             "2021-01":"y"
         },
         android: {
-            "2021-01":"n"
+            "2021-01":"n",
+            "2023-01":"y"
         }
     },
     hey: {


### PR DESCRIPTION
I'm not sure if desktop Gmail has lost support for `text-decoration-thickness` or if the original test was innacurate. 
All browsers support these features so it is not dependent on that. 