### PR TITLE
Attribute Selectors: update Gmail note

### DIFF
--- a/_features/css-selector-attribute.md
+++ b/_features/css-selector-attribute.md
@@ -16,13 +16,16 @@ stats: {
     },
     gmail: {
         desktop-webmail: {
-            "2020-12":"a #5"
+            "2020-12":"a #5",
+            "2023-02":"a #5"
         },
         ios: {
-            "2020-12":"a #5 #6"
+            "2020-12":"a #5 #6",
+            "2023-02":"a #5 #6"
         },
         android: {
-            "2020-12":"a #5 #6"
+            "2020-12":"a #5 #6",
+            "2023-02":"a #5 #6"
         },
         mobile-webmail: {
             "2020-02": "n"
@@ -176,7 +179,7 @@ notes_by_num: {
     "2": "Partial. Only supports `[attr]`, `[attr=value]`, `[attr~=value]`, `[attr|=value]` syntaxes.",
     "3": "Buggy. A `class=\"test\"` in the HTML is prefixed `class=\"x_test\"`, but an attribute selector stays unprefixed `[class=\"test\"]`.",
     "4": "Partial. Only supports `[attr=value]` syntax.",
-    "5": "Partial. Only supports `[attr~=value]` syntax.",
+    "5": "Partial. Only supports `[attr~=value]` syntax. Only `class` as an attribute name is known to be supported.",
     "6": "Partial. Doesn't work with Non Gmail Accounts."
 }
 links: {


### PR DESCRIPTION
Currently the attribute selector data table notes that the Gmail app has partial support:

> Partial. Only supports `[attr~=value]` syntax.

The above statement suggests this syntax works with any attribute name. However, I find that Gmail only supports `class` as an attribute name. So it only supports `[class~=value]`.

I've not tested every possible tag attribute, but I tested with the following:
- `height`
- `alt`
- `href`
- `style`

Nonetheless, I kept the updated note more generic (i.e. it doesn't say only `class` is supported):

> Only `class` as an attribute name is known to be supported.

---

Relevant: there is an opportunity to expand the test for attribute selectors to cover more common attribute names: https://github.com/hteumeuleu/caniemail/blob/master/tests/css-selectors-attribute.html