### PR TITLE
Apple Mail supports the `loading` attribute

### DIFF
--- a/_features/html-loading-attribute.md
+++ b/_features/html-loading-attribute.md
@@ -9,13 +9,13 @@ test_results_url: "https://testi.at/proj/BG3iM7ZhOjpi8Qlf4E9IQxg"
 stats: {
 	apple-mail: {
 		macos: {
-			"2021-10": "a #1"
+			"2021-10": "y #1"
 		},
 		ios: {
-			"11": "a #1",
-			"12": "a #1",
-			"13": "a #1",
-			"14": "a #1"
+			"11": "y #1",
+			"12": "y #1",
+			"13": "y #1",
+			"14": "y #1"
 		}
 	},
 	gmail: {


### PR DESCRIPTION
Apple Mail does support the `loading` attribute. Your note #1 says as much, “The loading attribute is supported, but not confirmed whether it works according to spec.” You apply the same note to Outlook and Samsung email — while giving them a `y` for a green box. Apple Mail should get the same treatment.