### PR TITLE
Remove template notes from `css-vertical-align.md`

### DIFF
--- a/_features/css-vertical-align.md
+++ b/_features/css-vertical-align.md
@@ -169,14 +169,6 @@ stats: {
 		}
 	}
 }
-notes: "This is a global note."
-notes_by_num: {
-    "1": "Partial. Fixed attachment is not supported.",
-    "2": "Partial. Slash syntax values are not supported.",
-    "3": "Partial. Values containing background images are not supported.",
-    "4": "Buggy. For slash syntax values, it removes the slash character, making the value invalid.",
-    "5": "Partial. Seems to only support background colors."
-}
 links: {
     "Can I use: vertical-align":"https://caniuse.com/mdn-css_properties_vertical-align",
     "MDN: vertical-align":"https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align"


### PR DESCRIPTION
# Remove template notes from `css-vertical-align.md`

Looks like there was some remnants of [`_template.md`] leftover in [`css-vertical-align.md`], this pull request removes those remnants.

[`_template.md`]: https://github.com/hteumeuleu/caniemail/blob/master/_features/_template.md
[`css-vertical-align.md`]: https://github.com/hteumeuleu/caniemail/blob/master/_features/css-vertical-align.md