### PR TITLE
Feature data: HTML hidden attribute

### DIFF
--- a/_features/html-hidden.md
+++ b/_features/html-hidden.md
@@ -179,7 +179,7 @@ stats: {
 }
 notes_by_num: {
     "1": "Does not support the unquoted attribute value syntax `<div hidden></div>`"
-},
+}
 links: {
   "MDN: hidden attribute":"https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden",
   "Can I use: hidden attribute":"https://caniuse.com/hidden"

--- a/_features/html-hidden.md
+++ b/_features/html-hidden.md
@@ -178,7 +178,7 @@ stats: {
   }
 }
 notes_by_num: {
-    "1": "Does not support the unquoted attribute value syntax `<div hidden></div>`",
+    "1": "Does not support the unquoted attribute value syntax `<div hidden></div>`"
 },
 links: {
   "MDN: hidden attribute":"https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden",

--- a/_features/html-hidden.md
+++ b/_features/html-hidden.md
@@ -1,0 +1,187 @@
+---
+title: "hidden attribute"
+description: "The global HTML `hidden` attribute"
+category: html
+tags: accessibility
+last_test_date: "2024-01-26"
+test_url: "/tests/html-hidden-attribute.html"
+test_results_url: "https://testi.at/proj/rlpli9r9trvs62rt7p"
+stats: {
+    apple-mail: {
+        macos: {
+            "20":"y",
+            "21":"y",
+            "22":"y",
+            "23":"y"
+        },
+        ios: {
+            "14":"y",
+            "15":"y",
+            "16":"y",
+            "17":"y"
+        }
+    },
+    gmail: {
+        desktop-webmail: {
+            "2024-01":"n"
+        },
+        ios: {
+            "2024-01":"n"
+        },
+        android: {
+            "2024-01":"n"
+        },
+        mobile-webmail: {
+            "2024-01":"n"
+        }
+    },
+    orange: {
+        desktop-webmail: {
+            "2024-01":"u"
+        },
+        ios: {
+            "2024-01":"u"
+        },
+        android: {
+            "2024-01":"u"
+        }
+    },
+    outlook: {
+        windows: {
+            "2003":"n",
+            "2007":"n",
+            "2010":"n",
+            "2013":"n",
+            "2016":"n",
+            "2019":"n"
+        },
+        windows-mail: {
+            "2024-01":"n"
+        },
+        macos: {
+            "2016":"y",
+            "2024-01":"n"
+        },
+        outlook-com: {
+            "2024-01":"n"
+        },
+        ios: {
+            "2024-01":"n"
+        },
+        android: {
+            "2024-01":"n"
+        }
+    },
+    samsung-email: {
+        android: {
+            "6.1":"y"
+        }
+    },
+    sfr: {
+        desktop-webmail: {
+            "2024-01":"u"
+        },
+        ios: {
+            "2024-01":"u"
+        },
+        android: {
+            "2024-01":"u"
+        }
+    },
+    thunderbird: {
+        macos: {
+            "60.3":"y"
+        }
+    },
+    aol: {
+        desktop-webmail: {
+            "2024-01":"n"
+        },
+        ios: {
+            "2024-01":"u"
+        },
+        android: {
+            "2024-01":"u"
+        }
+    },
+    yahoo: {
+        desktop-webmail: {
+            "2024-01":"n"
+        },
+        ios: {
+            "2024-01":"n"
+        },
+        android: {
+            "2024-01":"n"
+        }
+    },
+    protonmail: {
+        desktop-webmail: {
+            "2024-01":"u"
+        },
+        ios: {
+            "2024-01":"u"
+        },
+        android: {
+            "2024-01":"u"
+        }
+    },
+    hey: {
+        desktop-webmail: {
+            "2024-01":"u"
+        }
+    },
+    mail-ru: {
+        desktop-webmail: {
+            "2024-01":"a #1"
+        }
+    },
+    fastmail: {
+        desktop-webmail: {
+            "2024-01":"u"
+        }
+    },
+    laposte: {
+        desktop-webmail: {
+            "2024-01":"u"
+        }
+    },
+  gmx: {
+    desktop-webmail: {
+      "2024-01":"n"
+    },
+    ios: {
+      "2024-01":"u"
+    },
+    android: {
+      "2024-01":"u"
+    }
+  },
+  web-de: {
+    desktop-webmail: {
+      "2024-01":"n"
+    },
+    ios: {
+      "2024-01":"u"
+    },
+    android: {
+      "2024-01":"u"
+    }
+  },
+  ionos-1and1: {
+    desktop-webmail: {
+      "2024-01":"u"
+    },
+    android: {
+      "2024-01":"u"
+    }
+  }
+}
+notes_by_num: {
+    "1": "Does not support the unquoted attribute value syntax `<div hidden></div>`",
+},
+links: {
+  "MDN: hidden attribute":"https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden",
+  "Can I use: hidden attribute":"https://caniuse.com/hidden"
+}
+---

--- a/tests/html-hidden-attribute.html
+++ b/tests/html-hidden-attribute.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>hidden attribute</title>
+</head>
+<body>
+  <div>I'm visible</div>
+
+  <div hidden>hidden</div>
+
+  <div hidden="">hidden=""</div>
+
+  <div hidden="hidden">hidden="hidden"</div>
+
+  <div hidden="until-found">hidden="until-found"</div>
+
+  <div hidden="invalid-value">hidden="invalid-value"</div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a test and the feature data for the global HTML `hidden` attribute.

## until-found value
I have not tested the [`until-found` value](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden#the_hidden_until_found_state) on email clients that hide the element. This can be tested on webmail clients that support the `hidden` attribute.

> In the hidden until found state, the element is hidden but its content will be accessible to the browser's "find in page" feature or to fragment navigation.


## accessibility
I have added the `accessibility` tag to this because elements that have [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) can refer to hidden elements.
