### PR TITLE
Fix json order for comparison

### DIFF
--- a/_js/api-ordered.json
+++ b/_js/api-ordered.json
@@ -1,0 +1,45 @@
+---
+layout: null
+permalink: "/api/data-ordered.json"
+---
+{
+	"api_version":"1.0.4-ordered",
+	"last_update_date":{{site.time | jsonify}},
+	"nicenames":{{site.data.nicenames | jsonify}},
+	"data":[{% for feature in site.features %}
+		{
+			"slug":{{ feature.slug | jsonify }},
+			"title":{{ feature.title | jsonify }},
+			"description":{{ feature.description | jsonify }},
+			"url":{{ feature.url | prepend:site.url | jsonify }},
+			"category":{{ feature.category | jsonify }},
+			"tags":{{ feature.tags | jsonify }},
+			"keywords":{{ feature.keywords | jsonify }},
+			"last_test_date":{{ feature.last_test_date | jsonify }},
+			"test_url":{{ feature.test_url | prepend:site.url | jsonify }},
+			"test_results_url":{{ feature.test_results_url | jsonify }},
+			"stats":{
+				{%- for family in feature.stats -%}
+					{%- assign family-key = family | first -%}
+					{%- assign family-values = feature.stats[family-key] -%}
+					{{ family-key | jsonify }}:{
+						{%- for platform in family-values -%}
+							{%- assign platform-key = platform | first -%}
+							{%- assign platform-values = platform | last -%}
+							{{ platform-key | jsonify }}:[
+								{%- for version in platform-values -%}
+									{%- assign version-key = version | first -%}
+									{%- assign version-values = version | last | split: ' ' | first -%}
+									{ {{ version-key | jsonify }}:{{ version-values | jsonify }} }
+									{%- unless forloop.last -%},{%- endunless -%}
+								{%- endfor -%}
+							]{%- unless forloop.last -%},{%- endunless -%}
+						{%- endfor -%}
+					}{%- unless forloop.last -%},{%- endunless -%}
+				{%- endfor -%}
+			},
+			"notes":{{ feature.notes | jsonify}},
+			"notes_by_num":{{ feature.notes_by_num | jsonify}}
+		}{% unless forloop.last %},{% endunless %}
+	{% endfor %}]
+}

--- a/_js/compare.js
+++ b/_js/compare.js
@@ -218,7 +218,7 @@ class Compare {
 	loadJSONFile() {
 
 		if(!this.data) {
-			fetch('/api/data.json')
+			fetch('/api/data-ordered.json')
 			.then(response => {
 				return response.json();
 			})
@@ -305,8 +305,10 @@ class Compare {
 							const versions = feature.stats[key[0]][key[1]];
 							supportValue = 'u';
 							if(versions) {
-								const lastVersionKey = Object.keys(versions)[Object.keys(versions).length - 1];
-								const lastVersionValue = versions[lastVersionKey];
+								const lastVersion = versions[versions.length - 1];
+								const lastVersionKey = Object.keys(lastVersion)[0];
+								const lastVersionValue = lastVersion[lastVersionKey];
+								console.log(versions, lastVersionKey, lastVersionValue);
 								if(lastVersionValue) {
 									supportValue = lastVersionValue.charAt(0);
 								}
@@ -381,9 +383,12 @@ class Compare {
 					if(key[0] in feature.stats && key[1] in feature.stats[key[0]]) {
 						const versions = feature.stats[key[0]][key[1]];
 						if(versions) {
-							const lastVersionSupportValue = versions[Object.keys(versions)[Object.keys(versions).length - 1]];
+							// const lastVersionSupportValue = versions[Object.keys(versions)[Object.keys(versions).length - 1]];
+							const lastVersionSupportValue = versions[versions.length - 1];
 							if(lastVersionSupportValue) {
-								const supportValue = lastVersionSupportValue.charAt(0);
+								const key = Object.keys(lastVersionSupportValue)[0];
+								const value = lastVersionSupportValue[key];
+								const supportValue = value.charAt(0);
 								if(!averageSupportValue) {
 									averageSupportValue = supportValue;
 								} else if(averageSupportValue == 'u' && supportValue != 'u') {

--- a/pages/clients.html
+++ b/pages/clients.html
@@ -67,5 +67,5 @@ permalink: /clients/
 		</div>
 	</div>
 </div>
-<link rel="prefetch" href="/api/data.json" />
+<link rel="prefetch" href="/api/data-ordered.json" />
 <script src="/assets/js/compare.js" defer></script>


### PR DESCRIPTION
Related to #329

Adds a new `/api/data-ordered.json` file with each client version being in an ordered array in order to correctly retrieve and display data on the compare page.

Instead of: 

```
"apple-mail":{"macos":{"12.4":"n"},"ios":{"13.1":"n"}}
```

We now have:

```
"apple-mail":{"macos":[{ "12.4":"n" }],"ios":[{ "13.1":"n" }]}
```