### PR TITLE
Update HTML list test and data

### DIFF
--- a/_features/html-lists.md
+++ b/_features/html-lists.md
@@ -3,9 +3,9 @@ title: "<ul>, <ol> and <dl>"
 description: "Support for lists in HTML: `<ul>`, `<ol>`, `<li>`, `<dl>`, `<dt>` and `<dd>` elements."
 category: html
 keywords: ul, ol, li, dl, dt, dd
-last_test_date: "2020-04-20"
+last_test_date: "2024-02-17"
 test_url: "/tests/css-list.html"
-test_results_url: "https://app.emailonacid.com/app/acidtest/ifwlqtEsBCU23xVI7NgjBqvJlcJ4c20Akv3aRW3ugRJsP/list"
+test_results_url: "https://testi.at/proj/5jbpc3r2cknp15ayua"
 stats: {
     apple-mail: {
         macos: {
@@ -17,16 +17,20 @@ stats: {
     },
     gmail: {
         desktop-webmail: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         },
         ios: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         },
         android: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         },
         mobile-webmail: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         }
     },
     orange: {
@@ -43,30 +47,35 @@ stats: {
     },
     outlook: {
         windows: {
-            "2003":"y",
-            "2007":"y",
-            "2010":"y",
-            "2013":"y",
-            "2016":"y",
-            "2019":"y"
+            "2003":"a #1 #2",
+            "2007":"a #1 #2",
+            "2010":"a #1 #2",
+            "2013":"a #1 #2",
+            "2016":"a #1 #2",
+            "2019":"a #1 #2"
         },
         windows-mail: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1 #2"
         },
         macos: {
             "2011":"y",
             "2016":"y",
             "16.80":"y",
+            "2024-02":"a #1"
         },
         outlook-com: {
             "2020-04":"y",
             "2024-01":"y",
+            "2024-02":"a #1"
         },
         ios: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         },
         android: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         }
     },
     samsung-email: {
@@ -92,24 +101,30 @@ stats: {
     },
     aol: {
         desktop-webmail: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         },
         ios: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         },
         android: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         }
     },
     yahoo: {
         desktop-webmail: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         },
         ios: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         },
         android: {
-            "2020-04":"y"
+            "2020-04":"y",
+            "2024-02":"a #1"
         }
     },
     protonmail: {
@@ -130,7 +145,8 @@ stats: {
     },
     mail-ru: {
         desktop-webmail: {
-            "2020-10":"y"
+            "2020-10":"y",
+            "2024-02":"a #1"
         }
     },
     fastmail: {
@@ -173,5 +189,9 @@ stats: {
 			"2022-06":"y"
 		}
 	}
+}
+"notes_by_num": {
+	"1": "Partial. The `reversed` attribute on `<ol>` is not supported.",
+	"2": "Partila. Setting the `value` attribute to an `<li>` within an `<ol>` results in a different behaviour in comparison to browsers. The `<ol>` tag is closed before the `<li value=\"\">`. A new `<ol>` is added with the `start` attribute on it set to the value of the `value` attribute of the `<li>`."
 }
 ---

--- a/tests/css-list.html
+++ b/tests/css-list.html
@@ -55,6 +55,126 @@
 				</tr>
 				<tr>
 					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
+						&lt;ol&gt;&lt;li value&gt;
+					</td>
+					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">
+						<ol style="background-color:#bbe5b3;">
+							<li>Item 1</li>
+							<li value="4">Item 2 (value set to 4)</li>
+							<li>Item 3</li>
+						</ol>
+					</td>
+				</tr>
+				<tr>
+					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
+						&lt;ol reversed&gt;&lt;li&gt;
+					</td>
+					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">
+						<ol reversed style="background-color:#bbe5b3;">
+							<li>Item 1</li>
+							<li>Item 2</li>
+							<li>Item 3</li>
+						</ol>
+					</td>
+				</tr>
+				<tr>
+					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
+						&lt;ol reversed="true"&gt;&lt;li&gt;
+					</td>
+					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">
+						<ol reversed style="background-color:#bbe5b3;">
+							<li>Item 1</li>
+							<li>Item 2</li>
+							<li>Item 3</li>
+						</ol>
+					</td>
+				</tr>
+				<tr>
+					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
+						&lt;ol start="5"&gt;&lt;li&gt;
+					</td>
+					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">
+						<ol start="5" style="background-color:#bbe5b3;">
+							<li>Item 1</li>
+							<li>Item 2</li>
+							<li>Item 3</li>
+						</ol>
+					</td>
+				</tr>
+				<tr>
+					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
+						&lt;ol start="5" reversed&gt;&lt;li&gt;
+					</td>
+					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">
+						<ol start="5" reversed style="background-color:#bbe5b3;">
+							<li>Item 1</li>
+							<li>Item 2</li>
+							<li>Item 3</li>
+						</ol>
+					</td>
+				</tr>
+				<tr>
+					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
+						&lt;ol type="a"&gt;&lt;li&gt;
+					</td>
+					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">
+						<ol type="a" style="background-color:#bbe5b3;">
+							<li>Item 1</li>
+							<li>Item 2</li>
+							<li>Item 3</li>
+						</ol>
+					</td>
+				</tr>
+				<tr>
+					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
+						&lt;ol type="A"&gt;&lt;li&gt;
+					</td>
+					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">
+						<ol type="A" style="background-color:#bbe5b3;">
+							<li>Item 1</li>
+							<li>Item 2</li>
+							<li>Item 3</li>
+						</ol>
+					</td>
+				</tr>
+				<tr>
+					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
+						&lt;ol type="i"&gt;&lt;li&gt;
+					</td>
+					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">
+						<ol type="i" style="background-color:#bbe5b3;">
+							<li>Item 1</li>
+							<li>Item 2</li>
+							<li>Item 3</li>
+						</ol>
+					</td>
+				</tr>
+				<tr>
+					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
+						&lt;ol type="I"&gt;&lt;li&gt;
+					</td>
+					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">
+						<ol type="I" style="background-color:#bbe5b3;">
+							<li>Item 1</li>
+							<li>Item 2</li>
+							<li>Item 3</li>
+						</ol>
+					</td>
+				</tr>
+				<tr>
+					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
+						&lt;ol type="a"&gt;&lt;li value&gt;
+					</td>
+					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">
+						<ol type="a" style="background-color:#bbe5b3;">
+							<li>Item 1</li>
+							<li value="5">Item 2 (value set to 5)</li>
+							<li>Item 3</li>
+						</ol>
+					</td>
+				</tr>
+				<tr>
+					<td style="width:25%; vertical-align:top; padding:0.5em 1em 0.5em 0; border-right:1px solid lightgrey; font:16px monospace; border-top:1px solid lightgrey;">
 						&lt;dl&gt;&lt;dt&gt;&lt;dd&gt;
 					</td>
 					<td style="width:75%; vertical-align:top; padding:0.4em 0 0.4em 0.8em; font:20px serif; border-top:1px solid lightgrey;">


### PR DESCRIPTION
The test for the `<ol>` and `<li>` elements does not include the attribute they accept. This PR updates the test to include:

- `start` attribute on `<ol>`
- `reversed` boolean attribute on `<ol>`
- `type` attribute on `<ol>`
- `value` attribute on `<li>`

This PR does NOT include tests for:

- The deprecated `type` attribute on `<li>`

This PR also updates the support data based on the updated tests. A number of email clients go from full support to partial support as a result.

I do not have access to all emails clients on the list. So I have not tested the following:
- orange
- sfr
- protonmail
- hey
- fastmail
- laposte
- gmx
- web-de
- ionos-1and1