### PR TITLE
Local anchors not working on Fastmail

### DIFF
--- a/_features/html-anchor-links.md
+++ b/_features/html-anchor-links.md
@@ -136,7 +136,8 @@ stats: {
     },
 	fastmail: {
 		desktop-webmail: {
-			"2021-07": "y"
+			"2021-07": "y",
+			"2024-03": "n"
 		}
 	},
 	laposte: {


### PR DESCRIPTION
In my tests, Fastmail adds a `defanged<N>-` prefix to all local `id`s and `class`es, where `<N>` appears to be a changing number. Local anchors, however, are not adjusted, so your references will have `href="#foo"` while the target element will have something like `id="defanged1-foo"`.