### PR TITLE
Updated support data: <picture>

### DIFF
--- a/_features/html-picture.md
+++ b/_features/html-picture.md
@@ -4,13 +4,18 @@ description: "This is the description of the `<picture>` element."
 category: html
 keywords: picture, responsive image
 tags: accessibility performance
-last_test_date: "2019-05-29"
+last_test_date: "2024-04-15"
 test_url: "/tests/html-picture.html"
-test_results_url: "https://app.emailonacid.com/app/acidtest/AQoLHTLaC6F6JcMrkx38M7oyiJlAlXeRnJgkK06bSJiBR/list"
+test_results_url: "https://testi.at/proj/vr32cxxk1exntxrjfdp"
 stats: {
     apple-mail: {
         macos: {
-            "10.3":"y"
+            "10.3":"y",
+            "10.15":"a #2",
+            "11.7":"a #2",
+            "12.7":"a #2",
+            "13.6":"a #2",
+            "14.4":"a #2",
         },
         ios: {
             "10.3":"y",
@@ -179,6 +184,7 @@ stats: {
 }
 notes: ""
 notes_by_num: {
-    "1": "`<picture>` and `<source>` tags are replaced by `<u></u>` tags."
+    "1": "`<picture>` and `<source>` tags are replaced by `<u></u>` tags.",
+    "2": "`<picture>` tag is stripped in some cases."
 }
 ---

--- a/tests/html-picture.html
+++ b/tests/html-picture.html
@@ -6,10 +6,10 @@
 	<body>
 		<h1>picture</h1>
 		<picture>
-			<source srcset="https://i.imgur.com/35cz49W.png" media="(max-width: 480px)" />
-			<source srcset="https://i.imgur.com/X7vSnQV.png" media="(max-width: 640px)" />
-			<source srcset="https://i.imgur.com/JqqqI8g.png" media="(min-width: 641px)" />
-			<img src="https://i.imgur.com/pnUUCFQ.png" alt="" style="display:block; width:100%; height:auto;" />
+			<source srcset="https://40daystemp3.testi.at/placeholder/600x600/F4F4F4/5a5a5a.png?text=Small" media="(max-width: 480px)" />
+			<source srcset="https://40daystemp3.testi.at/placeholder/600x600/F4F4F4/5a5a5a.png?text=Medium" media="(max-width: 640px)" />
+			<source srcset="https://40daystemp3.testi.at/placeholder/600x600/F4F4F4/5a5a5a.png?text=Large" media="(min-width: 641px)" />
+			<img src="https://40daystemp3.testi.at/placeholder/600x600/F4F4F4/5a5a5a.png?text=Default" alt="" style="display:block; width:100%; height:auto;" />
 		</picture>
 	</body>
 </html>


### PR DESCRIPTION
The expected result is we see the appropriate placeholder images (large to small) according to the screen size. If this is not supported, we should see a placeholder image with the **Default** text on it.

In Apple Mail, there is an odd issue where the `picture` tag and its child elements gets stripped along with any sibling elements in certain use cases. I have included testi links below with some of the use cases.

- [picture tag with img](https://testi.at/proj/9zj3i524t5xz1be2u9)
 `picture` and `img` tags are stripped.

- [picture tag with text wrapped in div](https://testi.at/proj/ov530ajr0gb2fv341lk)
   This works as expected. However, an empty `div` tag strips the `picture` tag again.

I tried using `img` and `<div>Text</div>` together with `picture`. In this case, only the `img` tag is stripped. The `picture` and `div` tags remain and works as expected.