### PR TITLE
Support data: text-justify

### DIFF
--- a/_features/css-text-justify.md
+++ b/_features/css-text-justify.md
@@ -8,24 +8,24 @@ test_results_url: "https://testi.at/proj/z7b61px4fel2ivk9sb2"
 stats: {
   apple-mail: {
     macos: {
-      "2024-04": "n #1"
+      "2024-04":"n #1"
     },
     ios: {
-      "2024-04": "n #1"
+      "2024-04":"n #1"
     }
   },
   gmail: {
     desktop-webmail: {
-      "2024-04": "a #2"
+      "2024-04":"a #2"
     },
     ios: {
-      "2024-04": "n #1"
+      "2024-04":"n #1"
     },
     android: {
-     "2024-04": "n #1"
+     "2024-04":"n #1"
     },
     mobile-webmail: {
-      "2024-04": "a #2"
+      "2024-04":"a #2"
     }
   },
   orange: {
@@ -42,52 +42,52 @@ stats: {
   },
   outlook: {
     windows: {
-      "2013": "n",
-      "2016": "n",
-      "2019": "n",
-      "2021": "n"
+      "2013":"a #3",
+      "2016":"a #3",
+      "2019":"a #3",
+      "2021":"a #3"
     },
     windows-mail: {
-      "2024-04": "n"
+      "2024-04":"n #5"
     },
     macos: {
-      "2024-04": "n",
+      "2024-04":"n #1",
     },
     outlook-com: {
-      "2024-04": "a #2",
+      "2024-04":"a #2",
     },
     ios: {
-      "2024-04": "n #1"
+      "2024-04":"n #1"
     },
     android: {
-      "2024-04": "n #1"
+      "2024-04":"n #1"
     }
   },
   yahoo: {
     desktop-webmail: {
-      "2024-04": "n"
+      "2024-04":"a #2 #4"
     },
     ios: {
-      "2024-04": "n"
+      "2024-04":"n #1"
     },
     android: {
-      "2024-04": "n #1"
+      "2024-04":"n #1"
     }
   },
   aol: {
     desktop-webmail: {
-      "2024-04": "n"
+      "2024-04":"n #2 #4"
     },
     ios: {
-      "2024-04": "n"
+      "2024-04":"n #1"
     },
     android: {
-      "2024-04": "n #1"
+      "2024-04":"n #1"
     }
   },
   samsung-email: {
     android: {
-      "2024-04": "n #1"
+      "2024-04":"n #1"
     }
   },
   sfr: {
@@ -103,7 +103,7 @@ stats: {
   },
   thunderbird: {
     macos: {
-      "2024-04": "y"
+      "2024-04":"u"
     }
   },
   protonmail: {
@@ -124,22 +124,22 @@ stats: {
   },
   mail-ru: {
     desktop-webmail: {
-      "2024-04":"n"
+      "2024-04":"a #2"
     }
   },
   fastmail: {
     desktop-webmail: {
-      "2024-04": "u"
+      "2024-04":"u"
     }
   },
   laposte: {
     desktop-webmail: {
-      "2024-04": "u"
+      "2024-04":"u"
     }
   },
   gmx: {
     desktop-webmail: {
-      "2024-04": "n"
+      "2024-04":"a #2"
     },
     ios: {
       "2024-04":"u"
@@ -150,7 +150,7 @@ stats: {
   },
   web-de: {
     desktop-webmail: {
-      "2024-04": "a #1"
+      "2024-04":"n #1"
     },
     ios: {
       "2024-04":"u"
@@ -161,16 +161,20 @@ stats: {
   },
   ionos-1and1: {
     desktop-webmail: {
-      "2024-04": "u"
+      "2024-04":"u"
     },
     android: {
-      "2024-04": "u"
+      "2024-04":"u"
     }
   }
 },
 notes_by_num: {
   "1": "Buggy. `text-justify` is stripped",
   "2": "Partial. Depends on browser support",
+  "3": "Partial. `text-justify` is stripped except when the value is `inter-character`,
+  "4": "Partial. `text-justify` is stripped except when the value is `inter-word` or `distribute`,
+  "5": "Buggy. `text-justify` values `none`, `inter-word` and `distribute` are replaced with `inter-ideograph`,
+
 }
 links: {
   "Can I use: CSS text-justify":"https://caniuse.com/?search=text-justify",

--- a/_features/css-text-justify.md
+++ b/_features/css-text-justify.md
@@ -1,0 +1,179 @@
+---
+title: "text-justify"
+description: "Sets what type of justification should be applied to text when `text-align: justify;` is set on an element."
+category: css
+last_test_date: "2024-04-17"
+test_url: "/tests/css-text-justify.html"
+test_results_url: "https://testi.at/proj/z7b61px4fel2ivk9sb2"
+stats: {
+  apple-mail: {
+    macos: {
+      "2024-04": "n #1"
+    },
+    ios: {
+      "2024-04": "n #1"
+    }
+  },
+  gmail: {
+    desktop-webmail: {
+      "2024-04": "a #2"
+    },
+    ios: {
+      "2024-04": "n #1"
+    },
+    android: {
+     "2024-04": "n #1"
+    },
+    mobile-webmail: {
+      "2024-04": "a #2"
+    }
+  },
+  orange: {
+    desktop-webmail: {
+      "2024-04":"u",
+      "2024-04":"u"
+    },
+    ios: {
+      "2024-04":"u"
+    },
+    android: {
+      "2024-04":"u"
+    }
+  },
+  outlook: {
+    windows: {
+      "2013": "n",
+      "2016": "n",
+      "2019": "n",
+      "2021": "n"
+    },
+    windows-mail: {
+      "2024-04": "n"
+    },
+    macos: {
+      "2024-04": "n",
+    },
+    outlook-com: {
+      "2024-04": "a #2",
+    },
+    ios: {
+      "2024-04": "n #1"
+    },
+    android: {
+      "2024-04": "n #1"
+    }
+  },
+  yahoo: {
+    desktop-webmail: {
+      "2024-04": "n"
+    },
+    ios: {
+      "2024-04": "n"
+    },
+    android: {
+      "2024-04": "n #1"
+    }
+  },
+  aol: {
+    desktop-webmail: {
+      "2024-04": "n"
+    },
+    ios: {
+      "2024-04": "n"
+    },
+    android: {
+      "2024-04": "n #1"
+    }
+  },
+  samsung-email: {
+    android: {
+      "2024-04": "n #1"
+    }
+  },
+  sfr: {
+    desktop-webmail: {
+      "2024-04":"u"
+    },
+    ios: {
+      "2024-04":"u"
+    },
+    android: {
+      "2024-04":"u"
+    }
+  },
+  thunderbird: {
+    macos: {
+      "2024-04": "y"
+    }
+  },
+  protonmail: {
+    desktop-webmail: {
+      "2024-04":"u"
+    },
+    ios: {
+      "2024-04":"u"
+    },
+    android: {
+      "2024-04":"u"
+    }
+  },
+  hey: {
+    desktop-webmail: {
+      "2024-04":"u"
+    }
+  },
+  mail-ru: {
+    desktop-webmail: {
+      "2024-04":"n"
+    }
+  },
+  fastmail: {
+    desktop-webmail: {
+      "2024-04": "u"
+    }
+  },
+  laposte: {
+    desktop-webmail: {
+      "2024-04": "u"
+    }
+  },
+  gmx: {
+    desktop-webmail: {
+      "2024-04": "n"
+    },
+    ios: {
+      "2024-04":"u"
+    },
+    android: {
+      "2024-04":"u"
+    }
+  },
+  web-de: {
+    desktop-webmail: {
+      "2024-04": "a #1"
+    },
+    ios: {
+      "2024-04":"u"
+    },
+    android: {
+      "2024-04":"u"
+    }
+  },
+  ionos-1and1: {
+    desktop-webmail: {
+      "2024-04": "u"
+    },
+    android: {
+      "2024-04": "u"
+    }
+  }
+},
+notes_by_num: {
+  "1": "Buggy. `text-justify` is stripped",
+  "2": "Partial. Depends on browser support",
+}
+links: {
+  "Can I use: CSS text-justify":"https://caniuse.com/?search=text-justify",
+  "MDN: text-justify":"https://developer.mozilla.org/en-US/docs/Web/CSS/text-justify"
+}
+---

--- a/tests/css-text-justify.html
+++ b/tests/css-text-justify.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>text-wrap CSS property</title>
+  <style>
+    code {
+      color: red;
+    }
+  </style>
+</head>
+<body>
+<div style="padding:30px; max-width:400px;">
+<!--[if mso]>
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="400" align="center" style="border-spacing:0;">
+    <tr>
+      <td>
+<![endif]-->
+  <p style="border:1px solid; padding:12px; text-align:center; text-align:justify; text-justify:none;">
+    <code>text-justify:none;</code><br>
+    Integer elementum massa at nulla placerat varius.
+    Suspendisse in libero risus, in interdum massa.
+    Vestibulum ac leo vitae metus faucibus gravida ac in neque.
+  </p>
+
+  <p style="border:1px solid; padding:12px; text-align:center; text-align:justify; text-justify:inter-word;">
+    <code>text-justify:inter-word;</code><br>
+    Integer elementum massa at nulla placerat varius.
+    Suspendisse in libero risus, in interdum massa.
+    Vestibulum ac leo vitae metus faucibus gravida ac in neque.
+  </p>
+
+  <p style="border:1px solid; padding:12px; text-align:center; text-align:justify; text-justify:inter-character;">
+    <code>text-justify:inter-character;</code><br>
+    Integer elementum massa at nulla placerat varius.
+    Suspendisse in libero risus, in interdum massa.
+    Vestibulum ac leo vitae metus faucibus gravida ac in neque.
+  </p>
+
+  <p style="border:1px solid; padding:12px; text-align:center; text-align:justify; text-justify:distribute;">
+    <code>text-justify:distribute;</code><br>
+    Integer elementum massa at nulla placerat varius.
+    Suspendisse in libero risus, in interdum massa.
+    Vestibulum ac leo vitae metus faucibus gravida ac in neque.
+  </p>
+<!--[if mso]>
+    </td>
+  </tr>
+</table>
+<![endif]-->
+</div>
+</body>
+</html>


### PR DESCRIPTION
This PR tests support for the following values of `text-justify`:
`none`, `inter-character`, `inter-word` and `distribute`.

Note that the browser support for `text-justify` is limited to Firefox only.
