### PR TITLE
Typo fix - "long hadn" = "long hand"

### DIFF
--- a/_features/css-text-decoration.md
+++ b/_features/css-text-decoration.md
@@ -177,7 +177,7 @@ notes_by_num: {
     "2": "Partial. Not supported with multiple values.",
     "3": "Partial. `overline` is not supported.",
     "4": "Partial. Only supports the line property, not style, color or thickness.",
-    "5": "Partial. Only supports style, color or thickness when written with long hadn selectors."
+    "5": "Partial. Only supports style, color or thickness when written with long hand selectors."
 }
 links: {
     "Can I use: text-decoration": "https://caniuse.com/#feat=text-decoration",


### PR DESCRIPTION
Simple typo fix, hadn should have been hand.