### PR TITLE
Support data: cell-padding

### DIFF
--- a/_features/html-cell-padding.md
+++ b/_features/html-cell-padding.md
@@ -1,0 +1,176 @@
+---
+title: "cell-padding"
+description: "Represents the padding around the individual cells of the table"
+category: html
+last_test_date: "2024-05-01"
+test_url: "/tests/html-cell-spacing.html"
+test_results_url: "https://testi.at/proj/rlpatnzxf3eyce9oc3"
+stats: {
+  apple-mail: {
+    macos: {
+      "2024-05":"y"
+    },
+    ios: {
+      "2024-05":"y"
+    }
+  },
+  gmail: {
+    desktop-webmail: {
+      "2024-05":"y"
+    },
+    ios: {
+      "2024-05":"y"
+    },
+    android: {
+     "2024-05":"y"
+    },
+    mobile-webmail: {
+      "2024-05":"y"
+    }
+  },
+  orange: {
+    desktop-webmail: {
+      "2024-05":"u",
+      "2024-05":"u"
+    },
+    ios: {
+      "2024-05":"u"
+    },
+    android: {
+      "2024-05":"u"
+    }
+  },
+  outlook: {
+    windows: {
+      "2013":"y",
+      "2016":"y",
+      "2019":"y",
+      "2021":"y"
+    },
+    windows-mail: {
+      "2024-05":"y"
+    },
+    macos: {
+      "2024-05":"y",
+    },
+    outlook-com: {
+      "2024-05":"y",
+      "2024-01":"y"
+    },
+    ios: {
+      "2024-05":"y"
+    },
+    android: {
+      "2024-05":"y"
+    }
+  },
+  yahoo: {
+    desktop-webmail: {
+      "2024-05":"y"
+    },
+    ios: {
+      "2024-05":"y"
+    },
+    android: {
+      "2024-05":"y"
+    }
+  },
+  aol: {
+    desktop-webmail: {
+      "2024-05":"y"
+    },
+    ios: {
+      "2024-05":"y"
+    },
+    android: {
+      "2024-05":"y"
+    }
+  },
+  samsung-email: {
+    android: {
+      "2024-05":"y"
+    }
+  },
+  sfr: {
+    desktop-webmail: {
+      "2024-05":"u"
+    },
+    ios: {
+      "2024-05":"u"
+    },
+    android: {
+      "2024-05":"u"
+    }
+  },
+  thunderbird: {
+    macos: {
+      "2024-05":"y"
+    }
+  },
+  protonmail: {
+    desktop-webmail: {
+      "2024-05":"u"
+    },
+    ios: {
+      "2024-05":"u"
+    },
+    android: {
+      "2024-05":"u"
+    }
+  },
+  hey: {
+    desktop-webmail: {
+      "2024-05":"u"
+    }
+  },
+  mail-ru: {
+    desktop-webmail: {
+      "2024-05":"y"
+    }
+  },
+  fastmail: {
+    desktop-webmail: {
+      "2024-05": "u"
+    }
+  },
+  laposte: {
+    desktop-webmail: {
+      "2024-05": "u"
+    }
+  },
+  gmx: {
+    desktop-webmail: {
+       "2024-05":"y",
+    },
+    ios: {
+      "2024-05":"u"
+    },
+    android: {
+      "2024-05":"u"
+    }
+  },
+  web-de: {
+    desktop-webmail: {
+      "2024-05":"y",
+    },
+    ios: {
+      "2024-05":"u"
+    },
+    android: {
+      "2024-05":"u"
+    }
+  },
+  ionos-1and1: {
+    desktop-webmail: {
+      "2024-05": "u"
+    },
+    android: {
+      "2024-05": "u"
+    }
+  }
+}
+links: {
+  "MDN: cell-padding":"https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableElement/cellPadding",
+  "Can I use: cell-padding":"https://caniuse.com/?search=cell-padding"
+}
+---


### PR DESCRIPTION
This PR tests the support of the `cell-padding` attribute. Though this is marked deprecated by MDN, it is still widely supported in most email clients.