### PR TITLE
Update support of image base64: Gmail web still doesn't

### DIFF
--- a/_features/image-base64.md
+++ b/_features/image-base64.md
@@ -17,7 +17,7 @@ stats: {
     },
     gmail: {
         desktop-webmail: {
-            "2020-02":"n"
+            "2024-05":"n"
         },
         ios: {
             "2020-02":"n"

--- a/_features/image-base64.md
+++ b/_features/image-base64.md
@@ -17,7 +17,7 @@ stats: {
     },
     gmail: {
         desktop-webmail: {
-		    "2020-02":"n",
+            "2020-02":"n",
             "2024-05":"n"
         },
         ios: {

--- a/_features/image-base64.md
+++ b/_features/image-base64.md
@@ -17,6 +17,7 @@ stats: {
     },
     gmail: {
         desktop-webmail: {
+		    "2020-02":"n",
             "2024-05":"n"
         },
         ios: {


### PR DESCRIPTION
4 years later: sadly, Gmail still doesn't support images in base64. Tested web version in Chrome