### PR TITLE
Support data: white-space-collapse

### DIFF
--- a/_features/css-white-space-collapse.md
+++ b/_features/css-white-space-collapse.md
@@ -13,10 +13,10 @@ stats: {
       "11": "n",
       "12": "n",
       "13": "n",
-      "14": "y",
+      "14": "y #1",
     },
     ios: {
-      "15": "y"
+      "15": "y #1"
     }
   },
   gmail: {
@@ -91,7 +91,7 @@ stats: {
   },
   samsung-email: {
     android: {
-      "2024-09": "y"
+      "2024-09": "y #1"
     }
   },
   sfr: {
@@ -123,7 +123,7 @@ stats: {
   },
   mail-ru: {
     desktop-webmail: {
-      "2024-09":"y"
+      "2024-09":"y #1"
     }
   },
   fastmail: {
@@ -132,7 +132,9 @@ stats: {
     }
   }
 }
- 
+notes_by_num: {
+  "1": "Partial. `preserve-spaces` value works only on Firefox.",
+}
 links: {
   "Can I use: CSS property: white-space-collapse":"https://caniuse.com/css-white-space-collapse",
   "MDN: white-space-collapse":"https://developer.mozilla.org/en-US/docs/Web/CSS/white-space-collapse"

--- a/_features/css-white-space-collapse.md
+++ b/_features/css-white-space-collapse.md
@@ -1,0 +1,140 @@
+---
+title: "white-space-collapse"
+description: "Controls how white space inside an element is collapsed."
+category: css
+keywords: break, space, collapse, hide
+last_test_date: "2024-09-04"
+test_url: "/tests/css-white-space-collapse.html"
+test_results_url: "https://testi.at/proj/e6y4s3zytp5kty7kcg"
+stats: {
+  apple-mail: {
+    macos: {
+      "10": "n",
+      "11": "n",
+      "12": "n",
+      "13": "n",
+      "14": "y",
+    },
+    ios: {
+      "15": "y"
+    }
+  },
+  gmail: {
+    desktop-webmail: {
+      "2024-09": "n"
+    },
+    ios: {
+      "2024-09": "n"
+    },
+    android: {
+      "2024-09": "n"
+    },
+    mobile-webmail: {
+      "2024-09": "n"
+    }
+  },
+  orange: {
+    desktop-webmail: {
+      "2024-09":"u"
+    },
+    ios: {
+      "2024-09":"u"
+    },
+    android: {
+      "2024-09":"u"
+    }
+  },
+  outlook: {
+    windows: {
+      "2013": "n",
+      "2016": "n",
+      "2019": "n",
+      "2021": "n"
+    },
+    windows-mail: {
+      "2024-09": "n"
+    },
+    macos: {
+      "2024-09": "n",
+    },
+    outlook-com: {
+      "2024-09": "n",
+    },
+    ios: {
+      "2024-09": "n"
+    },
+    android: {
+      "2024-09": "n"
+    }
+  },
+  yahoo: {
+    desktop-webmail: {
+      "2024-09": "n"
+    },
+    ios: {
+     "2024-09": "n"
+    },
+    android: {
+      "2024-09": "n"
+    }
+  },
+  aol: {
+    desktop-webmail: {
+      "2024-09": "n"
+    },
+    ios: {
+      "2024-09": "n"
+    },
+    android: {
+      "2024-09": "n"
+    }
+  },
+  samsung-email: {
+    android: {
+      "2024-09": "y"
+    }
+  },
+  sfr: {
+    desktop-webmail: {
+      "2024-03":"u"
+    },
+    ios: {
+      "2024-03":"u"
+    },
+    android: {
+      "2024-03":"u"
+    }
+  }, 
+  protonmail: {
+    desktop-webmail: {
+      "2024-09":"u"
+    },
+    ios: {
+      "2024-09":"u"
+    },
+    android: {
+      "2024-09":"u"
+    }
+  },
+  hey: {
+    desktop-webmail: {
+      "2024-09":"u"
+    }
+  },
+  mail-ru: {
+    desktop-webmail: {
+      "2024-09":"y"
+    }
+  },
+  fastmail: {
+    desktop-webmail: {
+      "2024-09": "u"
+    }
+  }
+}
+ 
+links: {
+  "Can I use: CSS property: white-space-collapse":"https://caniuse.com/css-white-space-collapse",
+  "MDN: white-space-collapse":"https://developer.mozilla.org/en-US/docs/Web/CSS/white-space-collapse"
+}
+---

--- a/tests/css-white-space-collapse.html
+++ b/tests/css-white-space-collapse.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head></head>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>white-space-collapse CSS property</title>
+  <style>
+    code {
+      color: red;
+    }
+
+    p {
+      margin: 0;
+      border: 1px solid black;
+      margin-bottom: 10px;
+    }
+  </style>
+</head>
+<body>
+<div style="padding:30px;">
+<!--[if mso]>
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="400" align="center" style="border-spacing:0;">
+    <tr>
+      <td>
+<![endif]-->
+
+  <h1>white-space-collapse</h1>
+
+  <code>white-space-collapse: collapse;</code>
+  <p style="color:brown; white-space-collapse: collapse;">
+    Lorem ipsum dolor, 
+    
+    sit amet consectetur   adipisicing   elit.
+  </p>
+
+  <code>white-space-collapse: preserve;</code>
+  <p style="color:brown; white-space-collapse: preserve;">
+    Lorem ipsum dolor, 
+    
+    sit amet consectetur   adipisicing   elit.
+  </p>
+
+  <code>white-space-collapse: preserve-breaks;</code>
+  <p style="color:brown; white-space-collapse: preserve-breaks;">
+    Lorem ipsum dolor, 
+    
+    sit amet consectetur   adipisicing   elit.
+  </p>
+
+  <code>white-space-collapse: preserve-spaces;</code>
+  <p style="color:brown; white-space-collapse: preserve-spaces;">
+    Lorem ipsum dolor, 
+    
+    sit amet consectetur   adipisicing   elit.
+  </p>
+
+  <code>white-space-collapse: break-spaces;</code>
+  <p style="color:brown; white-space-collapse: break-spaces;">
+    Lorem ipsum dolor, 
+    
+    sit amet consectetur   adipisicing   elit.
+  </p>
+<!--[if mso]>
+    </td>
+  </tr>
+</table>
+<![endif]-->
+</div>
+</body>
+</html>


### PR DESCRIPTION
This PR includes support data for `white-space-collapse`.

Regarding Apple Mail on iOS, the `testi@` result is not accurate. When tested on a real iPhone 15 device, it works correctly. However, I cannot confirm the behavior on older iOS versions due to lack of access to older iPhone models.

Additionally, while there's no information on MDN or Can I Use about the support for the `preserve-spaces` value, it does appear to work in Firefox. However, in Safari and Chrome, it doesn’t seem to function as expected.

