### PR TITLE
Remove no longer relevant note

### DIFF
--- a/_features/html-style.md
+++ b/_features/html-style.md
@@ -226,6 +226,6 @@ notes_by_num: {
     "1": "Partial. Not supported inside the `<body>`.",
     "2": "Partial. Not supported with non Google accounts.",
     "3": "Buggy. The first `<head>` in the HTML is removed, so `<style>` elements need to be in a second `<head>` element.",
-    "4": "Buggy. `<style>` elements need to be declared before their rules are used.",
+    "4": "Buggy. `<style>` elements need to be declared before their rules are used."
 }
 ---

--- a/_features/html-style.md
+++ b/_features/html-style.md
@@ -227,6 +227,5 @@ notes_by_num: {
     "2": "Partial. Not supported with non Google accounts.",
     "3": "Buggy. The first `<head>` in the HTML is removed, so `<style>` elements need to be in a second `<head>` element.",
     "4": "Buggy. `<style>` elements need to be declared before their rules are used.",
-    "5": "A CSS rule following a CSS comment is ignored. (See [email-bugs#25](https://github.com/hteumeuleu/email-bugs/issues/25).)"
 }
 ---


### PR DESCRIPTION
Bug in Yahoo Mail was fixed, note is no longer included in the table, can be removed now.