### PR TITLE
Add Proton Mail support for hover pseudo-class

### DIFF
--- a/_features/css-pseudo-class-hover.md
+++ b/_features/css-pseudo-class-hover.md
@@ -114,10 +114,10 @@ stats: {
     },
     protonmail: {
         desktop-webmail: {
-            "2020-03":"n"
+            "2020-03":"y"
         },
         ios: {
-            "2020-03":"n"
+            "2020-03":"y"
         },
         android: {
             "2020-03":"y"


### PR DESCRIPTION
Hey there,

did test :hover support, works in Proton Mail too.

<img width="791" alt="Capture d’écran 2025-06-13 à 15 54 16" src="https://github.com/user-attachments/assets/259ddf5b-66f7-4702-9a58-91d3f98b2ca6" />

Cheers,


Nico