### PR TITLE
Add Proton Mail support for active pseudo-class

### DIFF
--- a/_features/css-pseudo-class-active.md
+++ b/_features/css-pseudo-class-active.md
@@ -113,10 +113,10 @@ stats: {
     },
     protonmail: {
         desktop-webmail: {
-            "2020-03":"n"
+            "2020-03":"y"
         },
         ios: {
-            "2020-03":"n"
+            "2020-03":"y"
         },
         android: {
             "2020-03":"y"


### PR DESCRIPTION
Hey there,

did test :active support, works in Proton Mail too.

Example on web:

<img width="789" alt="Capture d’écran 2025-06-13 à 15 55 04" src="https://github.com/user-attachments/assets/db605cbd-1776-4143-adf5-a573165c8a1d" />

Cheers,
Nico