### PR TITLE
Add Proton Mail support for focus pseudo-class

### DIFF
--- a/_features/css-pseudo-class-focus.md
+++ b/_features/css-pseudo-class-focus.md
@@ -113,10 +113,10 @@ stats: {
     },
     protonmail: {
         desktop-webmail: {
-            "2020-03":"n"
+            "2020-03":"y"
         },
         ios: {
-            "2020-03":"n"
+            "2020-03":"y"
         },
         android: {
             "2020-03":"y"


### PR DESCRIPTION
Hey again :)

did test :focus support, works in Proton Mail too.

Example on web:
<img width="793" alt="Capture d’écran 2025-06-13 à 15 54 32" src="https://github.com/user-attachments/assets/57bc1460-c6d2-44f9-ad7e-874e4bb9193e" />

Cheers,
Nico
