### PR TITLE
Add Proton Mail support for media-prefers-reduce-motion

### DIFF
--- a/_features/css-at-media-prefers-reduced-motion.md
+++ b/_features/css-at-media-prefers-reduced-motion.md
@@ -117,13 +117,13 @@ stats: {
 	},
 	protonmail: {
 		desktop-webmail: {
-			"2021-02": "n"
+			"2021-02": "a #2"
 		},
 		ios: {
-			"2021-02": "n"
+			"2021-02": "a #2"
 		},
 		android: {
-			"2021-02": "n"
+			"2021-02": "a #2"
 		}
 	},
 	hey: {
@@ -179,6 +179,7 @@ stats: {
 }
 notes_by_num: {
     "1": "Not supported. `@media (prefers-reduced-motion:reduce)` is transformed into `@media none`."
+	"2": "Partially supported. Not supported on `picture`."
 }
 links: {
 	"Can I use: prefers-reduced-motion":"https://caniuse.com/prefers-reduced-motion",


### PR DESCRIPTION


Hey again :)

did test media-prefers-reduce-motion support, works in Proton Mail partially too (not on picture tag, opened a bug for it).

Example on web:

<img width="687" alt="Capture d’écran 2025-06-13 à 19 31 16" src="https://github.com/user-attachments/assets/9ff54ba2-9ca3-4665-a5ef-f15dfd240ade" />

<img width="1255" alt="Capture d’écran 2025-06-13 à 19 31 24" src="https://github.com/user-attachments/assets/2e4e0a19-cd90-48ad-887a-067c7a4735e8" />


Same on mobile, example Android:

![image](https://github.com/user-attachments/assets/31738cb9-d9df-4965-9958-92992c99a9aa)



Cheers,
Nico
