### PR TITLE
fix: clarify :checked support on Free.fr webmail

### DIFF
--- a/_features/css-pseudo-class-checked.md
+++ b/_features/css-pseudo-class-checked.md
@@ -182,7 +182,7 @@ stats: {
 notes_by_num: {
     "1": "Partial. Only supported on type selectors.",
     "2": "Not supported. `<input>` elements are transformed into `<noinput>`.",
-    "3": "Only works when the attribute has an explicit value, e.g. only works when the attribute has an explicit value, e.g. `checked="checked"`"
+    "3": "Only works when the attribute has an explicit value, e.g. only works when the attribute has an explicit value, e.g. `checked=\"checked\"`"
 }
 links: {
     "Can I use: :checked":"https://caniuse.com/#feat=mdn-css_selectors_checked",


### PR DESCRIPTION
- **Free.fr webmail**: The `:checked` pseudo-class only works when the HTML attribute has an explicit value, for example:

  ```html
  <!-- Works on Free.fr -->
  <input type="checkbox" checked="checked">

  <!-- Does NOT work on Free.fr -->
  <input type="checkbox" checked>
