### PR TITLE
Add Proton Mail support for css-text-align-last

### DIFF
--- a/_features/css-text-align-last.md
+++ b/_features/css-text-align-last.md
@@ -79,6 +79,17 @@ stats: {
 			"6.1.51.1": "y"
 		}
 	},
+    protonmail: {
+      desktop-webmail: {
+        "2022-07":"y"
+      },
+      ios: {
+        "2022-07":"y"
+      },
+      android: {
+        "2022-07":"y"
+      }
+    },
 	free-fr: {
 		desktop-webmail: {
 			"2022-08": "y"


### PR DESCRIPTION
Another one there for the birthday :)

added support for text-align-last in Proton Mail (widely supported since forever I think :D ):

Web:


<img width="696" height="902" alt="Capture d’écran 2025-09-10 à 17 21 27" src="https://github.com/user-attachments/assets/4520279e-712a-4916-b18d-4d266e0ae598" />
<img width="656" height="842" alt="Capture d’écran 2025-09-10 à 17 21 37" src="https://github.com/user-attachments/assets/ac6a85c1-fe94-43df-85ff-f118dfe83b2e" />
<img width="660" height="883" alt="Capture d’écran 2025-09-10 à 17 21 48" src="https://github.com/user-attachments/assets/699c3bd0-6b7a-4b7c-b602-7e1940a06b50" />


Android:

<img width="1080" height="2340" alt="Screenshot_20250910-172041" src="https://github.com/user-attachments/assets/7972f339-7b13-4781-a9f4-6d039721e1f3" />
<img width="1080" height="2340" alt="Screenshot_20250910-172049" src="https://github.com/user-attachments/assets/fa09f972-eb67-4e12-8f93-b8ba5d633788" />
<img width="1080" height="2340" alt="Screenshot_20250910-172056" src="https://github.com/user-attachments/assets/17a3559b-3769-457a-937f-7afe5d38dacd" />

Cheers,
Nico