### PR TITLE
Update text-indent support for Proton Mail

### DIFF
--- a/_features/css-text-indent.md
+++ b/_features/css-text-indent.md
@@ -117,7 +117,7 @@ stats: {
   },
   protonmail: {
     desktop-webmail: {
-      "2021-01":"y"
+      "2021-01":"a #2"
     },
     ios: {
       "2021-01":"y"


### PR DESCRIPTION
Hello there,

I've just patched email rendering in Proton Mail web app, so we avoid support for negative values for `text-indent` (mostly because of some emails going crazy)

When I write, this is not yet live, will update as soon as it's deployed -> this will be deployed next Wednesday, so can be merged :)


Cheers,
Nico