### PR TITLE
Add Thunderbird 149.0.1 test result for CSS animation (not supported)

### DIFF
--- a/_features/css-animation.md
+++ b/_features/css-animation.md
@@ -3,7 +3,7 @@ title: "animation"
 description: "Tests for the shorthand `animation` property and its longhand equivalents."
 category: css
 keywords: keyframes
-last_test_date: "2023-12-19"
+last_test_date: "2026-04-07"
 test_url: "/tests/css-animation.html"
 test_results_url: "https://app.emailonacid.com/app/acidtest/u4oWccYOFNNyTagHs2NSUZqJYQ3MssrqDMocBnRa35hf7/list"
 stats: {
@@ -85,7 +85,8 @@ stats: {
     },
     thunderbird: {
         macos: {
-            "78.10":"y"
+            "78.10":"y",
+  			"149.0.1":"n"
         }
     },
     aol: {


### PR DESCRIPTION
Tested manually on Thunderbird 149.0.1 (macOS) using the existing test file `/tests/css-animation.html`.                                                                                                    
                                                                                                                                                                                                              
CSS animations with @keyframes are no longer rendered in this version, confirming a regression from version 78.10 where they were fully supported.

  **Test environment:**
  - Platform: Thunderbird macOS
  - Version: 149.0.1
  - Test method: Direct testing with local email client
  - Test date: 2026-04-07