### PR TITLE
Add Proton Mail support for resize

### DIFF
--- a/_features/css-resize.md
+++ b/_features/css-resize.md
@@ -108,13 +108,13 @@ stats: {
   },
   protonmail: {
     desktop-webmail: {
-      "2024-01":"u"
+      "2024-01":"a #3"
     },
     ios: {
       "2024-01":"n"
     },
     android: {
-      "2024-01":"u"
+      "2024-01":"a #4"
     }
   },
   hey: {
@@ -171,6 +171,8 @@ stats: {
 notes_by_num: {
   "1": "`resize` property is stripped from style tag",
   "2": "Does not support `inline` and `block` values",
+  "3": "Supported but depends of browser support",
+  "4": "Supported but barely usable, system gesture management often take priority",
 }
 links: {
   "Can I use: CSS resize":"https://caniuse.com/?search=resize",


### PR DESCRIPTION
Hello there!

Added support for resize for Proton Mail, added a few notes:

- works on a browser like Chrome with full support, not on browsers with partial support like Firefox/Safari - works only on `div`/`p` 2 first examples)
- on Android, works too, but barely usable - OS and app system gestures take often priority, so it's hard to use

Ex on Mail Web with Chrome:

<img width="841" height="397" alt="Capture d’écran 2026-05-15 à 11 48 23" src="https://github.com/user-attachments/assets/c592e8f3-b48d-42bb-993f-ced3bf5de825" />
<img width="729" height="688" alt="Capture d’écran 2026-05-15 à 11 48 16" src="https://github.com/user-attachments/assets/e9242a85-94c4-489a-b26f-0c19f98081be" />



Ex on Android:

First display looks like this:

<img width="1080" height="2340" alt="Screenshot_20260515-114407" src="https://github.com/user-attachments/assets/1617318f-5653-47e8-bb36-1edc46cccecb" />



I managed to resize, but as written in the note: it's barely usable.

<img width="1080" height="2340" alt="Screenshot_20260515-114436" src="https://github.com/user-attachments/assets/079f375f-6c53-4018-92f7-09c67e51d7d7" />
<img width="1080" height="2340" alt="Screenshot_20260515-114626" src="https://github.com/user-attachments/assets/dc9eda16-4db0-4616-8cb5-21c9ee5b90e3" />



Cheers,
Nico


