### PR TITLE
Add Proton Mail support for mask-image

### DIFF
--- a/_features/css-mask-image.md
+++ b/_features/css-mask-image.md
@@ -114,13 +114,13 @@ stats: {
   }, 
   protonmail: {
     desktop-webmail: {
-      "2024-11":"u"
+      "2024-11":"a #1"
     },
     ios: {
-      "2024-11":"u"
+      "2024-11":"a #1"
     },
     android: {
-      "2024-11":"u"
+      "2024-11":"a #1"
     }
   },
   hey: {
@@ -174,7 +174,9 @@ stats: {
     }
   }
 }
- 
+notes_by_num: {
+ "1": "Notation using `url` is not supported.",
+}
 links: {
   "Can I use: CSS property: mask-image":"https://caniuse.com/mask-image",
   "MDN: mask-image":"https://developer.mozilla.org/en-US/docs/Web/CSS/mask-image"


### PR DESCRIPTION
Hello there,

- Add Proton Mail support for mask-image (no support for `url` notation)

Ex. on Web:

<img width="707" height="808" alt="Capture d’écran 2026-05-19 à 10 16 51" src="https://github.com/user-attachments/assets/547ad14e-0079-41a3-9fd1-3397c77e4984" />


Ex. on Android:

<img width="1080" height="2340" alt="Screenshot_20260519-101623" src="https://github.com/user-attachments/assets/72f969af-cc7d-4346-b602-5fc22a0b258f" />



Cheers,
Nicolas