### PR TITLE
Add Proton Mail support for word-wrap

### DIFF
--- a/_features/css-word-wrap.md
+++ b/_features/css-word-wrap.md
@@ -46,12 +46,24 @@ stats: {
         desktop-webmail: {
             "2025-05":"y"
         }
-    }
+    },
+	protonmail: {
+        desktop-webmail: {
+            "2025-05":"y"
+        },
+        ios: {
+          "2024-11":"a #4"
+        },
+        android: {
+          "2024-11":"a #4"
+        }
+    },
 }
 notes_by_num: {
     "1": "Applies `word-wrap: break-word` to all items.",
     "2": "Does not honor any wrapping, including `word-wrap`, `overflow-wrap`, and `word-break`. Using an equivalent MSO breakdown (`-ms-word-break: break-all` and `mso-hyphenate: none` together) does not work.",
-    "3": "Supports both `word-wrap` and equivalent MSO breakdown (`-ms-word-break: break-all` and `mso-hyphenate: none` together)"
+    "3": "Supports both `word-wrap` and equivalent MSO breakdown (`-ms-word-break: break-all` and `mso-hyphenate: none` together)",
+	"4": "`word-wrap` is correctly supported, however `word-break` seems to break for all values"
 }
 links: {
     "Can I use: word-wrap":"https://caniuse.com/wordwrap",


### PR DESCRIPTION
Hello there,

- Add Proton Mail support for word-wrap (okay on web, inconsistent on mobile)


Ex. on Web:

<img width="690" height="734" alt="Capture d’écran 2026-05-19 à 11 10 04" src="https://github.com/user-attachments/assets/26276cfa-300e-4541-9397-26b4d9f2422c" />
<img width="531" height="756" alt="Capture d’écran 2026-05-19 à 11 10 17" src="https://github.com/user-attachments/assets/b44f0086-3721-4397-807f-c525ba11201b" />



Ex. on Android:

<img width="1080" height="2340" alt="Screenshot_20260519-113100" src="https://github.com/user-attachments/assets/2d8bffdc-5fa1-4739-85f7-6083d3f2a406" />
<img width="1080" height="2340" alt="Screenshot_20260519-113110" src="https://github.com/user-attachments/assets/3d453791-a202-41b6-b2ac-6d03654b9793" />



Cheers,
Nico