### PR TITLE
Add Proton Mail support for hyphens

### DIFF
--- a/_features/css-hyphens.md
+++ b/_features/css-hyphens.md
@@ -116,13 +116,13 @@ stats: {
   }, 
   protonmail: {
     desktop-webmail: {
-      "2022-08":"u"
+      "2022-08":"y"
     },
     ios: {
-      "2022-08":"u"
+      "2022-08":"y #1"
     },
     android: {
-      "2022-08":"u"
+      "2022-08":"y #1"
     }
   },
   hey: {
@@ -141,7 +141,9 @@ stats: {
     }
   }
 }
- 
+notes_by_num: {
+    "1": "Applies an equivalent behaviour of `word-wrap: break-word` for mobile.",
+}
 links: {
   "Can I use: CSS property: hyphens":"https://caniuse.com/css-hyphens",
   "MDN: hyphens":"https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens"


### PR DESCRIPTION
Hello there,

- Added Proton Mail support for hyphens : okay for web and mobile, just a different behaviour on mobile (added in notes)

Ex. on Web:

<img width="268" height="510" alt="Capture d’écran 2026-05-21 à 11 06 02" src="https://github.com/user-attachments/assets/7f074fad-eec1-4cfb-bf7e-4c7e23b230b6" />

Ex. on Android (same for iOS):

<img width="1080" height="2340" alt="Screenshot_20260521-110631" src="https://github.com/user-attachments/assets/340f7317-d52d-4222-afd3-a6c92f03fde3" />



Cheers,
Nicolas